### PR TITLE
Add mgc_framebuffer_t and perform related refactoring

### DIFF
--- a/src/mgc/common/common.h
+++ b/src/mgc/common/common.h
@@ -79,13 +79,32 @@ typedef mgc_color_rgb565_t mgc_color_t;
 
 #ifndef MGC_GET_PIXELBUF_INDEX
 #if MGC_PIXELBUF_ORDER==0U
-#define MGC_GET_PIXELBUF_INDEX(x, y) \
-    ((MGC_MOD_CELL_LEN((x))<<MGC_CELL_LEN_LOG2) + MGC_MOD_CELL_LEN((y)))
+#define MGC_GET_PIXELBUF_INDEX(x, y, w, h) \
+    (size_t)(h) * (size_t)(x) + (size_t)(y);
 #else
-#define MGC_GET_PIXELBUF_INDEX(x, y) \
-    ((MGC_MOD_CELL_LEN((y))<<MGC_CELL_LEN_LOG2) + MGC_MOD_CELL_LEN((x)))
+#define MGC_GET_PIXELBUF_INDEX(x, y, w, h) \
+    (size_t)(w) * (size_t)(y) + (size_t)(x);
 #endif
 #endif
+
+#ifndef MGC_GET_PIXELBUF_INDEX_OPTIMIZED_16X16
+#if MGC_PIXELBUF_ORDER==0U
+#define MGC_GET_PIXELBUF_INDEX_OPTIMIZED_16X16(x, y) \
+    ((size_t)(x)<<MGC_CELL_LEN_LOG2) + (size_t)(y);
+#else
+#define MGC_GET_PIXELBUF_INDEX_OPTIMIZED_16X16(x, y) \
+    ((size_t)(y)<<MGC_CELL_LEN_LOG2) + (size_t)(x);
+#endif
+#endif
+
+typedef struct mgc_point {
+    int16_t x;
+    int16_t y;
+} mgc_point_t;
+
+typedef struct mgc_draw_options {
+    uint32_t reserved;
+} mgc_draw_options_t;
 
 #ifdef __cplusplus
 }/* extern "C" */

--- a/src/mgc/common/common.h
+++ b/src/mgc/common/common.h
@@ -106,6 +106,8 @@ typedef struct mgc_draw_options {
     uint32_t reserved;
 } mgc_draw_options_t;
 
+#define MGC_PARALLAX_SHIFT(coord, factor) (int16_t)((coord) * (factor))
+
 #ifdef __cplusplus
 }/* extern "C" */
 #endif

--- a/src/mgc/components/dialoguebox.c
+++ b/src/mgc/components/dialoguebox.c
@@ -222,32 +222,6 @@ enum mgc_display_text_state dialoguebox_get_display_text_state(const mgc_dialogu
     return dialoguebox->textblock.state;
 }
 
-bool dialoguebox_apply_cell_blending(
-    const mgc_dialoguebox_t *dialoguebox,
-    mgc_pixelbuffer_t *pixelbuffer,
-    int16_t cell_x,
-    int16_t cell_y
-) {
-    bool is_blending = false;
-    if ( ( dialoguebox == NULL ) ||
-         ( pixelbuffer == NULL )
-    ) {
-        MGC_WARN("Invalid handler");
-        return false;
-    }
-    if ( dialoguebox->enabled == false ) {
-        MGC_INFO("Handler is disabled");
-        return false;
-    }
-    if ( rect_apply_cell_blending(&dialoguebox->bg_box, pixelbuffer, cell_x, cell_y) == true ) {
-        is_blending = true;
-    }
-    if ( textblock_apply_cell_blending(&dialoguebox->textblock, pixelbuffer, cell_x, cell_y) == true ) {
-        is_blending = true;
-    }
-    return is_blending;
-}
-
 bool dialoguebox_draw(
     const mgc_dialoguebox_t *dialoguebox,
     mgc_framebuffer_t *fb,
@@ -274,3 +248,48 @@ bool dialoguebox_draw(
     }
     return is_blending;
 }
+
+bool dialoguebox_draw_cell(
+        const mgc_dialoguebox_t *dialoguebox,
+        mgc_pixelbuffer_t *pb,
+        int16_t cell_x,
+        int16_t cell_y,
+        const mgc_point_t *cam_pos,
+        const mgc_draw_options_t *options
+) {
+    if ( ( dialoguebox == NULL ) ||
+         ( pb == NULL )
+    ) {
+        MGC_WARN("Invalid handler");
+        return false;
+    }
+    if ( dialoguebox->enabled == false ) {
+        MGC_INFO("Handler is disabled");
+        return false;
+    }
+
+    if ( rect_draw_cell(&dialoguebox->bg_box, pb, cell_x, cell_y, cam_pos, options) == true ) {
+        textblock_draw_cell(&dialoguebox->textblock, pb, cell_x, cell_y, cam_pos, options);
+        return true;
+    } else {
+        return false;
+    }
+}
+
+// Legacy
+bool dialoguebox_apply_cell_blending(
+    const mgc_dialoguebox_t *dialoguebox,
+    mgc_pixelbuffer_t *pixelbuffer,
+    int16_t cell_x,
+    int16_t cell_y
+) {
+    if ( pixelbuffer == NULL ) {
+        MGC_WARN("Invalid handler");
+        return false;
+    }
+
+    mgc_point_t cam_pos = {pixelbuffer->cell_x_ofs, pixelbuffer->cell_y_ofs};
+
+    return dialoguebox_draw_cell(dialoguebox, pixelbuffer, cell_x, cell_y, &cam_pos, NULL);
+}
+

--- a/src/mgc/components/dialoguebox.c
+++ b/src/mgc/components/dialoguebox.c
@@ -248,3 +248,29 @@ bool dialoguebox_apply_cell_blending(
     return is_blending;
 }
 
+bool dialoguebox_draw(
+    const mgc_dialoguebox_t *dialoguebox,
+    mgc_framebuffer_t *fb,
+    const mgc_point_t *cam_pos,
+    const mgc_draw_options_t *options
+) {
+    bool is_blending = false;
+    if ( ( dialoguebox == NULL ) ||
+         ( fb == NULL ) ||
+         ( fb->buffer == NULL )
+    ) {
+        MGC_WARN("Invalid handler");
+        return false;
+    }
+    if ( dialoguebox->enabled == false ) {
+        MGC_INFO("Handler is disabled");
+        return false;
+    }
+    if ( rect_draw(&dialoguebox->bg_box, fb, cam_pos, options) == true ) {
+        is_blending = true;
+    }
+    if ( textblock_draw(&dialoguebox->textblock, fb, cam_pos, options) == true ) {
+        is_blending = true;
+    }
+    return is_blending;
+}

--- a/src/mgc/components/dialoguebox.c
+++ b/src/mgc/components/dialoguebox.c
@@ -155,13 +155,13 @@ void dialoguebox_set_text(mgc_dialoguebox_t *dialoguebox, const char *text) {
     textblock_set_text(&dialoguebox->textblock, text);
 }
 
-void dialoguebox_set_r_cell_offset(mgc_dialoguebox_t *dialoguebox, uint8_t r_cell_x_ofs, uint8_t r_cell_y_ofs) {
+void dialoguebox_set_parallax_factor(mgc_dialoguebox_t *dialoguebox, float factor_x, float factor_y) {
     if ( dialoguebox == NULL ) {
         MGC_WARN("Invalid handler");
         return;
     }
-    rect_set_r_cell_offset(&dialoguebox->bg_box, r_cell_x_ofs, r_cell_y_ofs);
-    textblock_set_r_cell_offset(&dialoguebox->textblock, r_cell_x_ofs, r_cell_y_ofs);
+    rect_set_parallax_factor(&dialoguebox->bg_box, factor_x, factor_y);
+    textblock_set_parallax_factor(&dialoguebox->textblock, factor_x, factor_y);
 }
 
 void dialoguebox_set_scroll_line(mgc_dialoguebox_t *dialoguebox, uint8_t scroll_line) {
@@ -276,7 +276,7 @@ bool dialoguebox_draw_cell(
     }
 }
 
-// Legacy
+//////////////////////////////// Legacy ////////////////////////////////
 bool dialoguebox_apply_cell_blending(
     const mgc_dialoguebox_t *dialoguebox,
     mgc_pixelbuffer_t *pixelbuffer,
@@ -292,4 +292,14 @@ bool dialoguebox_apply_cell_blending(
 
     return dialoguebox_draw_cell(dialoguebox, pixelbuffer, cell_x, cell_y, &cam_pos, NULL);
 }
+
+void dialoguebox_set_r_cell_offset(mgc_dialoguebox_t *dialoguebox, uint8_t r_cell_x_ofs, uint8_t r_cell_y_ofs) {
+    if ( dialoguebox == NULL ) {
+        MGC_WARN("Invalid handler");
+        return;
+    }
+    rect_set_r_cell_offset(&dialoguebox->bg_box, r_cell_x_ofs, r_cell_y_ofs);
+    textblock_set_r_cell_offset(&dialoguebox->textblock, r_cell_x_ofs, r_cell_y_ofs);
+}
+
 

--- a/src/mgc/components/dialoguebox.h
+++ b/src/mgc/components/dialoguebox.h
@@ -44,8 +44,18 @@ void dialoguebox_adjust_height(mgc_dialoguebox_t *dialoguebox);
 void dialoguebox_display_update(mgc_dialoguebox_t *dialoguebox);
 void dialoguebox_display_clear(mgc_dialoguebox_t *dialoguebox);
 enum mgc_display_text_state dialoguebox_get_display_text_state(const mgc_dialoguebox_t *dialoguebox);
-bool dialoguebox_apply_cell_blending(const mgc_dialoguebox_t *dialoguebox, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y);
 bool dialoguebox_draw(const mgc_dialoguebox_t *dialoguebox, mgc_framebuffer_t *fb, const mgc_point_t *cam_pos, const mgc_draw_options_t *options);
+bool dialoguebox_draw_cell(
+        const mgc_dialoguebox_t *dialoguebox,
+        mgc_pixelbuffer_t *pb,
+        int16_t cell_x,
+        int16_t cell_y,
+        const mgc_point_t *cam_pos,
+        const mgc_draw_options_t *options
+);
+
+// Legacy
+bool dialoguebox_apply_cell_blending(const mgc_dialoguebox_t *dialoguebox, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y);
 
 #ifdef __cplusplus
 }/* extern "C" */

--- a/src/mgc/components/dialoguebox.h
+++ b/src/mgc/components/dialoguebox.h
@@ -45,6 +45,7 @@ void dialoguebox_display_update(mgc_dialoguebox_t *dialoguebox);
 void dialoguebox_display_clear(mgc_dialoguebox_t *dialoguebox);
 enum mgc_display_text_state dialoguebox_get_display_text_state(const mgc_dialoguebox_t *dialoguebox);
 bool dialoguebox_apply_cell_blending(const mgc_dialoguebox_t *dialoguebox, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y);
+bool dialoguebox_draw(const mgc_dialoguebox_t *dialoguebox, mgc_framebuffer_t *fb, const mgc_point_t *cam_pos, const mgc_draw_options_t *options);
 
 #ifdef __cplusplus
 }/* extern "C" */

--- a/src/mgc/components/dialoguebox.h
+++ b/src/mgc/components/dialoguebox.h
@@ -37,7 +37,7 @@ void dialoguebox_set_back_color(mgc_dialoguebox_t *dialoguebox, mgc_color_t back
 void dialoguebox_set_cursor_speed(mgc_dialoguebox_t *dialoguebox, uint8_t cursor_speed);
 void dialoguebox_set_scroll_speed(mgc_dialoguebox_t *dialoguebox, uint8_t scroll_speed);
 void dialoguebox_set_line_spacing(mgc_dialoguebox_t *dialoguebox, uint8_t line_spacing);
-void dialoguebox_set_r_cell_offset(mgc_dialoguebox_t *dialoguebox, uint8_t r_cell_x_ofs, uint8_t r_cell_y_ofs);
+void dialoguebox_set_parallax_factor(mgc_dialoguebox_t *dialoguebox, float factor_x, float factor_y);
 void dialoguebox_set_text(mgc_dialoguebox_t *dialoguebox, const char *text);
 void dialoguebox_set_scroll_line(mgc_dialoguebox_t *dialoguebox, uint8_t scroll_line);
 void dialoguebox_adjust_height(mgc_dialoguebox_t *dialoguebox);
@@ -54,8 +54,9 @@ bool dialoguebox_draw_cell(
         const mgc_draw_options_t *options
 );
 
-// Legacy
+//////////////////////////////// Legacy ////////////////////////////////
 bool dialoguebox_apply_cell_blending(const mgc_dialoguebox_t *dialoguebox, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y);
+void dialoguebox_set_r_cell_offset(mgc_dialoguebox_t *dialoguebox, uint8_t r_cell_x_ofs, uint8_t r_cell_y_ofs);
 
 #ifdef __cplusplus
 }/* extern "C" */

--- a/src/mgc/components/label.c
+++ b/src/mgc/components/label.c
@@ -220,19 +220,6 @@ static inline bool draw_buffer(
     return true;
 }
 
-bool label_apply_cell_blending(const mgc_label_t *label, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y) {
-
-    if ( pixelbuffer == NULL ) {
-        MGC_WARN("Invalid handler");
-        return false;
-    }
-
-    mgc_point_t cam_pos = {pixelbuffer->cell_x_ofs, pixelbuffer->cell_y_ofs};
-    mgc_point_t fov_ofs = {cell_x, cell_y};
-
-    return draw_buffer(label, pixelbuffer->pixelbuf, MGC_CELL_LEN, MGC_CELL_LEN, &cam_pos, &fov_ofs, NULL);
-}
-
 bool label_draw(const mgc_label_t *label, mgc_framebuffer_t *fb, const mgc_point_t *cam_pos, const mgc_draw_options_t *options) {
 
     if ( (fb == NULL) || (fb->buffer == NULL) ) {
@@ -243,5 +230,36 @@ bool label_draw(const mgc_label_t *label, mgc_framebuffer_t *fb, const mgc_point
     mgc_point_t fov_ofs = {0, 0};
 
     return draw_buffer(label, fb->buffer, fb->width, fb->height, cam_pos, &fov_ofs, options);
+}
+
+bool label_draw_cell(
+        const mgc_label_t *label,
+        mgc_pixelbuffer_t *pb,
+        int16_t cell_x,
+        int16_t cell_y,
+        const mgc_point_t *cam_pos,
+        const mgc_draw_options_t *options
+) {
+    if ( pb == NULL ) {
+        MGC_WARN("Invalid handler");
+        return false;
+    }
+
+    mgc_point_t fov_ofs = {cell_x, cell_y};
+
+    return draw_buffer(label, pb->pixelbuf, MGC_CELL_LEN, MGC_CELL_LEN, cam_pos, &fov_ofs, options);
+}
+
+// Legacy
+bool label_apply_cell_blending(const mgc_label_t *label, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y) {
+
+    if ( pixelbuffer == NULL ) {
+        MGC_WARN("Invalid handler");
+        return false;
+    }
+
+    mgc_point_t cam_pos = {pixelbuffer->cell_x_ofs, pixelbuffer->cell_y_ofs};
+
+    return label_draw_cell(label, pixelbuffer, cell_x, cell_y, &cam_pos, NULL);
 }
 

--- a/src/mgc/components/label.c
+++ b/src/mgc/components/label.c
@@ -98,7 +98,16 @@ void label_set_enable_back_color(mgc_label_t *label, bool enable) {
     label->enable_back_color = enable;
 }
 
-bool label_apply_cell_blending(const mgc_label_t *label, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y) {
+static inline bool draw_buffer(
+        const mgc_label_t *label,
+        mgc_color_t *draw_buf,
+        uint16_t buf_width,
+        uint16_t buf_height,
+        const mgc_point_t *cam_pos,
+        const mgc_point_t *fov_ofs,
+        const mgc_draw_options_t *options
+) {
+    // 0: label, 1:camera
     int16_t l0, l1;
     int16_t r0, r1, r0_w;
     int16_t t0, t1;
@@ -111,7 +120,7 @@ bool label_apply_cell_blending(const mgc_label_t *label, mgc_pixelbuffer_t *pixe
 
     if ( ( label == NULL )       ||
          ( label->font == NULL ) ||
-         ( pixelbuffer == NULL )
+         ( draw_buf == NULL )
     ) {
         MGC_WARN("Invalid handler");
         return false;
@@ -120,8 +129,12 @@ bool label_apply_cell_blending(const mgc_label_t *label, mgc_pixelbuffer_t *pixe
         MGC_INFO("Handler is disabled");
         return false;
     }
+
+    (void)options;
+
     scale = label->fontsize2x ? 2 : 1;
     shift = scale-1;
+
     l0 = label->x;
     t0 = label->y;
     b0 = t0 + label->font->fbb_y*scale - 1;
@@ -130,16 +143,24 @@ bool label_apply_cell_blending(const mgc_label_t *label, mgc_pixelbuffer_t *pixe
     }
     r0_w = l0 + label->width;
 
-    l1 = cell_x;
-    t1 = cell_y;
-    if ( label->r_cell_x_ofs != 0 ) {
-        l1 += pixelbuffer->cell_x_ofs / label->r_cell_x_ofs;
+
+    if ( fov_ofs != NULL ) {
+        l1 = fov_ofs->x;
+        t1 = fov_ofs->y;
+    } else {
+        l1 = 0;
+        t1 = 0;
     }
-    if ( label->r_cell_y_ofs != 0 ) {
-        t1 += pixelbuffer->cell_y_ofs / label->r_cell_y_ofs;
+    if ( cam_pos != NULL ) {
+        if ( label->r_cell_x_ofs != 0 ) {
+            l1 += cam_pos->x / label->r_cell_x_ofs;
+        }
+        if ( label->r_cell_y_ofs != 0 ) {
+            t1 += cam_pos->y / label->r_cell_y_ofs;
+        }
     }
-    r1 = l1 + MGC_CELL_LEN - 1;
-    b1 = t1 + MGC_CELL_LEN - 1;
+    r1 = l1 + buf_width - 1;
+    b1 = t1 + buf_height - 1;
 
     if ( (r0_w < l1) || (r1 < l0) || (b0 < t1) || (b1 < t0) ) {
         /* Blending not required */
@@ -181,13 +202,13 @@ bool label_apply_cell_blending(const mgc_label_t *label, mgc_pixelbuffer_t *pixe
                     for ( int16_t Y = y_s; Y <= y_e; Y++ ) {
                         if ( (bitmap[Y>>shift] & mask_x ) != 0 ) {
                             size_t idx;
-                            idx = MGC_GET_PIXELBUF_INDEX(X+l0-l1, Y+t0-t1);
-                            pixelbuffer->pixelbuf[idx] = label->fore_color;
+                            idx = MGC_GET_PIXELBUF_INDEX(X+l0-l1, Y+t0-t1, buf_width, buf_height);
+                            draw_buf[idx] = label->fore_color;
                         } else {
                             if ( label->enable_back_color ) {
                                 size_t idx;
-                                idx = MGC_GET_PIXELBUF_INDEX(X+l0-l1, Y+t0-t1);
-                                pixelbuffer->pixelbuf[idx] = label->back_color;
+                                idx = MGC_GET_PIXELBUF_INDEX(X+l0-l1, Y+t0-t1, buf_width, buf_height);
+                                draw_buf[idx] = label->back_color;
                             }
                         }
                     }
@@ -197,5 +218,30 @@ bool label_apply_cell_blending(const mgc_label_t *label, mgc_pixelbuffer_t *pixe
         }
     }
     return true;
+}
+
+bool label_apply_cell_blending(const mgc_label_t *label, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y) {
+
+    if ( pixelbuffer == NULL ) {
+        MGC_WARN("Invalid handler");
+        return false;
+    }
+
+    mgc_point_t cam_pos = {pixelbuffer->cell_x_ofs, pixelbuffer->cell_y_ofs};
+    mgc_point_t fov_ofs = {cell_x, cell_y};
+
+    return draw_buffer(label, pixelbuffer->pixelbuf, MGC_CELL_LEN, MGC_CELL_LEN, &cam_pos, &fov_ofs, NULL);
+}
+
+bool label_draw(const mgc_label_t *label, mgc_framebuffer_t *fb, const mgc_point_t *cam_pos, const mgc_draw_options_t *options) {
+
+    if ( (fb == NULL) || (fb->buffer == NULL) ) {
+        MGC_WARN("Invalid handler");
+        return false;
+    }
+
+    mgc_point_t fov_ofs = {0, 0};
+
+    return draw_buffer(label, fb->buffer, fb->width, fb->height, cam_pos, &fov_ofs, options);
 }
 

--- a/src/mgc/components/label.h
+++ b/src/mgc/components/label.h
@@ -43,8 +43,18 @@ void label_set_text(mgc_label_t *label, const char *text);
 void label_set_fore_color(mgc_label_t *label, mgc_color_t fore_color);
 void label_set_back_color(mgc_label_t *label, mgc_color_t back_color);
 void label_set_enable_back_color(mgc_label_t *label, bool enable);
-bool label_apply_cell_blending(const mgc_label_t *label, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y);
 bool label_draw(const mgc_label_t *label, mgc_framebuffer_t *fb, const mgc_point_t *cam_pos, const mgc_draw_options_t *options);
+bool label_draw_cell(
+        const mgc_label_t *label,
+        mgc_pixelbuffer_t *pb,
+        int16_t cell_x,
+        int16_t cell_y,
+        const mgc_point_t *cam_pos,
+        const mgc_draw_options_t *options
+);
+
+// Legacy
+bool label_apply_cell_blending(const mgc_label_t *label, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y);
 
 #ifdef __cplusplus
 }/* extern "C" */

--- a/src/mgc/components/label.h
+++ b/src/mgc/components/label.h
@@ -24,8 +24,8 @@ typedef struct mgc_label {
     uint16_t width;
     uint16_t height;
     bool enabled;
-    uint8_t r_cell_x_ofs;
-    uint8_t r_cell_y_ofs;
+    float parallax_factor_x;
+    float parallax_factor_y;
     const char *text;
     const mgc_font_t *font;
     mgc_color_t fore_color;
@@ -38,7 +38,7 @@ void label_init(mgc_label_t *label, mgc_id_t id, const mgc_font_t *font, bool fo
 void label_set_enabled(mgc_label_t *label, bool enabled);
 void label_set_position(mgc_label_t *label, int16_t x, int16_t y);
 void label_set_size(mgc_label_t *label, uint16_t width, uint16_t height);
-void label_set_r_cell_offset(mgc_label_t *label, uint8_t r_cell_x_ofs, uint8_t r_cell_y_ofs);
+void label_set_parallax_factor(mgc_label_t *label, float factor_x, float factor_y);
 void label_set_text(mgc_label_t *label, const char *text);
 void label_set_fore_color(mgc_label_t *label, mgc_color_t fore_color);
 void label_set_back_color(mgc_label_t *label, mgc_color_t back_color);
@@ -53,8 +53,10 @@ bool label_draw_cell(
         const mgc_draw_options_t *options
 );
 
-// Legacy
+//////////////////////////////// Legacy ////////////////////////////////
 bool label_apply_cell_blending(const mgc_label_t *label, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y);
+void label_set_r_cell_offset(mgc_label_t *label, uint8_t r_cell_x_ofs, uint8_t r_cell_y_ofs);
+
 
 #ifdef __cplusplus
 }/* extern "C" */

--- a/src/mgc/components/label.h
+++ b/src/mgc/components/label.h
@@ -15,6 +15,7 @@ extern "C" {
 #include "mgc/font/font.h"
 #include "mgc/font/encoding.h"
 #include "mgc/render/pixelbuffer.h"
+#include "mgc/render/framebuffer.h"
 
 typedef struct mgc_label {
     mgc_id_t id;
@@ -43,6 +44,7 @@ void label_set_fore_color(mgc_label_t *label, mgc_color_t fore_color);
 void label_set_back_color(mgc_label_t *label, mgc_color_t back_color);
 void label_set_enable_back_color(mgc_label_t *label, bool enable);
 bool label_apply_cell_blending(const mgc_label_t *label, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y);
+bool label_draw(const mgc_label_t *label, mgc_framebuffer_t *fb, const mgc_point_t *cam_pos, const mgc_draw_options_t *options);
 
 #ifdef __cplusplus
 }/* extern "C" */

--- a/src/mgc/components/rect.c
+++ b/src/mgc/components/rect.c
@@ -6,34 +6,6 @@
  */
 #include "rect.h"
 
-typedef struct draw_box {
-    int16_t right;
-    int16_t left;
-    int16_t top;
-    int16_t bottom;
-} draw_box_t;
-
-static inline bool apply_cell_blending(mgc_color_t *pixelbuf, const draw_box_t *target, const draw_box_t *cell, mgc_color_t color) {
-    if ( (target->left<=cell->right) && (cell->left<=target->right) && (target->top<=cell->bottom) && (cell->top<=target->bottom) ) {
-        int16_t x, y;
-        int16_t x_s, y_s, x_e, y_e;
-        x_s = (( cell->left   < target->left   ) ? target->left : cell->left     ) - target->left;
-        x_e = (( cell->right  < target->right  ) ? cell->right  : target->right  ) - target->left;
-        y_s = (( cell->top    < target->top    ) ? target->top  : cell->top      ) - target->top;
-        y_e = (( cell->bottom < target->bottom ) ? cell->bottom : target->bottom ) - target->top;
-        for ( x = x_s; x <= x_e; x++ ) {
-            for ( y = y_s; y <= y_e; y++ ) {
-                size_t idx;
-                idx = MGC_GET_PIXELBUF_INDEX(x+target->left-cell->left, y+target->top-cell->top);
-                pixelbuf[idx] = color;
-            }
-        }
-        return true;
-    } else {
-        return false;
-    }
-}
-
 void rect_init(mgc_rect_t *rect, mgc_id_t id) {
     if ( rect == NULL ) {
         MGC_WARN("Invalid handler");
@@ -118,11 +90,23 @@ void rect_set_r_cell_offset(mgc_rect_t *rect, uint8_t r_cell_x_ofs, uint8_t r_ce
     rect->r_cell_y_ofs = r_cell_y_ofs;
 }
 
-bool rect_apply_cell_blending(const mgc_rect_t *rect, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y) {
-    draw_box_t box_target, box_cell;
-    bool is_blending = false;
+static inline bool draw_buffer(
+        const mgc_rect_t *rect,
+        mgc_color_t *draw_buf,
+        uint16_t buf_width,
+        uint16_t buf_height,
+        const mgc_point_t *cam_pos,
+        const mgc_point_t *fov_ofs,
+        const mgc_draw_options_t *options
+) {
+    // 0: rect, 1: camera
+    int16_t l0, l1;
+    int16_t r0, r1;
+    int16_t t0, t1;
+    int16_t b0, b1;
+
     if ( ( rect == NULL ) ||
-         ( pixelbuffer == NULL )
+         ( draw_buf == NULL )
     ) {
         MGC_WARN("Invalid handler");
         return false;
@@ -132,36 +116,96 @@ bool rect_apply_cell_blending(const mgc_rect_t *rect, mgc_pixelbuffer_t *pixelbu
         return false;
     }
 
-    box_cell.left = cell_x;
-    box_cell.top  = cell_y;
-    if ( rect->r_cell_x_ofs != 0 ) {
-        box_cell.left += pixelbuffer->cell_x_ofs / rect->r_cell_x_ofs;
-    }
-    if ( rect->r_cell_y_ofs != 0 ) {
-        box_cell.top += pixelbuffer->cell_y_ofs / rect->r_cell_y_ofs;
-    }
-    box_cell.right  = box_cell.left + MGC_CELL_LEN - 1;
-    box_cell.bottom = box_cell.top  + MGC_CELL_LEN - 1;
+    (void)options;
 
-    if ( rect->border_width > 0 ) {
+    l0 = rect->x - rect->border_width;
+    t0 = rect->y - rect->border_width;
+    r0 = l0 + rect->border_width + rect->width - 1;
+    b0 = t0 + rect->border_width + rect->height - 1;
 
-        box_target.left   = rect->x - rect->border_width;
-        box_target.right  = rect->x + rect->border_width + rect->width - 1;
-        box_target.top    = rect->y - rect->border_width;
-        box_target.bottom = rect->y + rect->border_width + rect->height - 1;
-        if ( apply_cell_blending(pixelbuffer->pixelbuf, &box_target, &box_cell, rect->border_color) == true ) {
-            is_blending = true;
+    if ( fov_ofs != NULL ) {
+        l1 = fov_ofs->x;
+        t1 = fov_ofs->y;
+    } else {
+        l1 = 0;
+        t1 = 0;
+    }
+    if ( cam_pos != NULL ) {
+        if ( rect->r_cell_x_ofs != 0 ) {
+            l1 += cam_pos->x / rect->r_cell_x_ofs;
+        }
+        if ( rect->r_cell_y_ofs != 0 ) {
+            t1 += cam_pos->y / rect->r_cell_y_ofs;
         }
     }
+    r1 = l1 + buf_width - 1;
+    b1 = t1 + buf_height - 1;
 
-    box_target.left   = rect->x;
-    box_target.right  = rect->x + rect->width - 1;
-    box_target.top    = rect->y;
-    box_target.bottom = rect->y + rect->height - 1;
-    if ( apply_cell_blending(pixelbuffer->pixelbuf, &box_target, &box_cell, rect->inner_color) == true ) {
-        is_blending = true;
+    if ( (l0<=r1) && (l1<=r0) && (t0<=b1) && (t1<=b0) ) {
+        int16_t x, y;
+        int16_t x_s, y_s, x_e, y_e;
+        mgc_color_t color;
+
+        if ( rect->border_width > 0 ) {
+
+            color = rect->border_color;
+            x_s = (( l1 < l0 ) ? l0 : l1) - l0;
+            x_e = (( r1 < r0 ) ? r1 : r0) - l0;
+            y_s = (( t1 < t0 ) ? t0 : t1) - t0;
+            y_e = (( b1 < b0 ) ? b1 : b0) - t0;
+
+            for ( x = x_s; x <= x_e; x++ ) {
+                for ( y = y_s; y <= y_e; y++ ) {
+                    size_t idx = MGC_GET_PIXELBUF_INDEX(x+l0-l1, y+t0-t1, buf_width, buf_height);
+                    draw_buf[idx] = color;
+                }
+            }
+            l0 += rect->border_width;
+            t0 += rect->border_width;
+            r0 -= rect->border_width;
+            b0 -= rect->border_width;
+        }
+
+        color = rect->inner_color;
+        x_s = (( l1 < l0 ) ? l0 : l1) - l0;
+        x_e = (( r1 < r0 ) ? r1 : r0) - l0;
+        y_s = (( t1 < t0 ) ? t0 : t1) - t0;
+        y_e = (( b1 < b0 ) ? b1 : b0) - t0;
+
+        for ( x = x_s; x <= x_e; x++ ) {
+            for ( y = y_s; y <= y_e; y++ ) {
+                size_t idx = MGC_GET_PIXELBUF_INDEX(x+l0-l1, y+t0-t1, buf_width, buf_height);
+                draw_buf[idx] = color;
+            }
+        }
+        return true;
+    } else {
+        return false;
+    }
+}
+
+bool rect_apply_cell_blending(const mgc_rect_t *rect, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y) {
+
+    if ( pixelbuffer == NULL ) {
+        MGC_WARN("Invalid handler");
+        return false;
     }
 
-    return is_blending;
+    mgc_point_t cam_pos = {pixelbuffer->cell_x_ofs, pixelbuffer->cell_y_ofs};
+    mgc_point_t fov_ofs = {cell_x, cell_y};
+
+    return draw_buffer(rect, pixelbuffer->pixelbuf, MGC_CELL_LEN, MGC_CELL_LEN, &cam_pos, &fov_ofs, NULL);
+}
+
+bool rect_draw(const mgc_rect_t *rect, mgc_framebuffer_t *fb, const mgc_point_t *cam_pos, const mgc_draw_options_t *options) {
+
+    if ( (fb == NULL) || (fb->buffer == NULL) ) {
+        MGC_WARN("Invalid handler");
+        return false;
+    }
+
+    mgc_point_t fov_ofs = {0, 0};
+
+    return draw_buffer(rect, fb->buffer, fb->width, fb->height, cam_pos, &fov_ofs, options);
 }
 

--- a/src/mgc/components/rect.c
+++ b/src/mgc/components/rect.c
@@ -184,19 +184,6 @@ static inline bool draw_buffer(
     }
 }
 
-bool rect_apply_cell_blending(const mgc_rect_t *rect, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y) {
-
-    if ( pixelbuffer == NULL ) {
-        MGC_WARN("Invalid handler");
-        return false;
-    }
-
-    mgc_point_t cam_pos = {pixelbuffer->cell_x_ofs, pixelbuffer->cell_y_ofs};
-    mgc_point_t fov_ofs = {cell_x, cell_y};
-
-    return draw_buffer(rect, pixelbuffer->pixelbuf, MGC_CELL_LEN, MGC_CELL_LEN, &cam_pos, &fov_ofs, NULL);
-}
-
 bool rect_draw(const mgc_rect_t *rect, mgc_framebuffer_t *fb, const mgc_point_t *cam_pos, const mgc_draw_options_t *options) {
 
     if ( (fb == NULL) || (fb->buffer == NULL) ) {
@@ -209,3 +196,33 @@ bool rect_draw(const mgc_rect_t *rect, mgc_framebuffer_t *fb, const mgc_point_t 
     return draw_buffer(rect, fb->buffer, fb->width, fb->height, cam_pos, &fov_ofs, options);
 }
 
+bool rect_draw_cell(
+        const mgc_rect_t *rect,
+        mgc_pixelbuffer_t *pb,
+        int16_t cell_x,
+        int16_t cell_y,
+        const mgc_point_t *cam_pos,
+        const mgc_draw_options_t *options
+) {
+    if ( pb == NULL ) {
+        MGC_WARN("Invalid handler");
+        return false;
+    }
+
+    mgc_point_t fov_ofs = {cell_x, cell_y};
+
+    return draw_buffer(rect, pb->pixelbuf, MGC_CELL_LEN, MGC_CELL_LEN, cam_pos, &fov_ofs, options);
+}
+
+// Legacy
+bool rect_apply_cell_blending(const mgc_rect_t *rect, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y) {
+
+    if ( pixelbuffer == NULL ) {
+        MGC_WARN("Invalid handler");
+        return false;
+    }
+
+    mgc_point_t cam_pos = {pixelbuffer->cell_x_ofs, pixelbuffer->cell_y_ofs};
+
+    return rect_draw_cell(rect, pixelbuffer, cell_x, cell_y, &cam_pos, NULL);
+}

--- a/src/mgc/components/rect.h
+++ b/src/mgc/components/rect.h
@@ -38,8 +38,18 @@ void rect_set_border_width(mgc_rect_t *rect, uint16_t border_width);
 void rect_set_inner_color(mgc_rect_t *rect, mgc_color_t inner_color);
 void rect_set_border_color(mgc_rect_t *rect, mgc_color_t border_color);
 void rect_set_r_cell_offset(mgc_rect_t *rect, uint8_t r_cell_x_ofs, uint8_t r_cell_y_ofs);
-bool rect_apply_cell_blending(const mgc_rect_t *rect, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y);
 bool rect_draw(const mgc_rect_t *rect, mgc_framebuffer_t *fb, const mgc_point_t *cam_pos, const mgc_draw_options_t *options);
+bool rect_draw_cell(
+        const mgc_rect_t *rect,
+        mgc_pixelbuffer_t *pb,
+        int16_t cell_x,
+        int16_t cell_y,
+        const mgc_point_t *cam_pos,
+        const mgc_draw_options_t *options
+);
+
+// Legacy
+bool rect_apply_cell_blending(const mgc_rect_t *rect, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y);
 
 #ifdef __cplusplus
 }/* extern "C" */

--- a/src/mgc/components/rect.h
+++ b/src/mgc/components/rect.h
@@ -20,8 +20,8 @@ typedef struct mgc_rect {
     bool enabled;
     int16_t x;
     int16_t y;
-    uint8_t r_cell_x_ofs;
-    uint8_t r_cell_y_ofs;
+    uint8_t parallax_factor_x;
+    uint8_t parallax_factor_y;
     uint16_t width;
     uint16_t height;
     uint16_t border_width;
@@ -37,7 +37,7 @@ void rect_set_height(mgc_rect_t *rect, uint16_t height);
 void rect_set_border_width(mgc_rect_t *rect, uint16_t border_width);
 void rect_set_inner_color(mgc_rect_t *rect, mgc_color_t inner_color);
 void rect_set_border_color(mgc_rect_t *rect, mgc_color_t border_color);
-void rect_set_r_cell_offset(mgc_rect_t *rect, uint8_t r_cell_x_ofs, uint8_t r_cell_y_ofs);
+void rect_set_parallax_factor(mgc_rect_t *rect, float factor_x, float factor_y);
 bool rect_draw(const mgc_rect_t *rect, mgc_framebuffer_t *fb, const mgc_point_t *cam_pos, const mgc_draw_options_t *options);
 bool rect_draw_cell(
         const mgc_rect_t *rect,
@@ -48,8 +48,9 @@ bool rect_draw_cell(
         const mgc_draw_options_t *options
 );
 
-// Legacy
+//////////////////////////////// Legacy ////////////////////////////////
 bool rect_apply_cell_blending(const mgc_rect_t *rect, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y);
+void rect_set_r_cell_offset(mgc_rect_t *rect, uint8_t r_cell_x_ofs, uint8_t r_cell_y_ofs);
 
 #ifdef __cplusplus
 }/* extern "C" */

--- a/src/mgc/components/rect.h
+++ b/src/mgc/components/rect.h
@@ -13,6 +13,7 @@ extern "C" {
 
 #include "mgc/common/common.h"
 #include "mgc/render/pixelbuffer.h"
+#include "mgc/render/framebuffer.h"
 
 typedef struct mgc_rect {
     mgc_id_t id;
@@ -38,6 +39,7 @@ void rect_set_inner_color(mgc_rect_t *rect, mgc_color_t inner_color);
 void rect_set_border_color(mgc_rect_t *rect, mgc_color_t border_color);
 void rect_set_r_cell_offset(mgc_rect_t *rect, uint8_t r_cell_x_ofs, uint8_t r_cell_y_ofs);
 bool rect_apply_cell_blending(const mgc_rect_t *rect, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y);
+bool rect_draw(const mgc_rect_t *rect, mgc_framebuffer_t *fb, const mgc_point_t *cam_pos, const mgc_draw_options_t *options);
 
 #ifdef __cplusplus
 }/* extern "C" */

--- a/src/mgc/components/selectbox.c
+++ b/src/mgc/components/selectbox.c
@@ -295,3 +295,36 @@ bool selectbox_apply_cell_blending(const mgc_selectbox_t *selectbox, mgc_pixelbu
     return is_blending;
 }
 
+bool selectbox_draw(const mgc_selectbox_t *selectbox, mgc_framebuffer_t *fb, const mgc_point_t *cam_pos, const mgc_draw_options_t *options) {
+
+    bool is_blending = false;
+    if ( ( selectbox == NULL ) ||
+         ( fb == NULL ) ||
+         ( fb->buffer == NULL )
+    ) {
+        MGC_WARN("Invalid handler");
+        return false;
+    }
+    if ( selectbox->enabled == false ) {
+        MGC_INFO("Handler is disabled");
+        return false;
+    }
+    if ( selectbox->item_count == 0 ) {
+        MGC_WARN("Empty items");
+        return false;
+    }
+    if ( rect_draw(&selectbox->bg_box, fb, cam_pos, options) == true ) {
+        is_blending = true;
+    }
+    for ( size_t i = 0; i < selectbox->item_count; i++ ) {
+        if ( label_draw(&selectbox->item[i], fb, cam_pos, options) == true ) {
+            is_blending = true;
+        }
+    }
+    if ( label_draw(&selectbox->cursor, fb, cam_pos, options) == true ) {
+        is_blending = true;
+    }
+
+    return is_blending;
+}
+

--- a/src/mgc/components/selectbox.c
+++ b/src/mgc/components/selectbox.c
@@ -264,37 +264,6 @@ void selectbox_set_r_cell_offset(mgc_selectbox_t *selectbox, uint8_t r_cell_x_of
     }
 }
 
-bool selectbox_apply_cell_blending(const mgc_selectbox_t *selectbox, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y) {
-    bool is_blending = false;
-    if ( ( selectbox == NULL ) ||
-         ( pixelbuffer == NULL )
-    ) {
-        MGC_WARN("Invalid handler");
-        return false;
-    }
-    if ( selectbox->enabled == false ) {
-        MGC_INFO("Handler is disabled");
-        return false;
-    }
-    if ( selectbox->item_count == 0 ) {
-        MGC_WARN("Empty items");
-        return false;
-    }
-    if ( rect_apply_cell_blending(&selectbox->bg_box, pixelbuffer, cell_x, cell_y) == true ) {
-        is_blending = true;
-    }
-    for ( size_t i = 0; i < selectbox->item_count; i++ ) {
-        if ( label_apply_cell_blending(&selectbox->item[i], pixelbuffer, cell_x, cell_y) == true ) {
-            is_blending = true;
-        }
-    }
-    if ( label_apply_cell_blending(&selectbox->cursor, pixelbuffer, cell_x, cell_y) == true ) {
-        is_blending = true;
-    }
-
-    return is_blending;
-}
-
 bool selectbox_draw(const mgc_selectbox_t *selectbox, mgc_framebuffer_t *fb, const mgc_point_t *cam_pos, const mgc_draw_options_t *options) {
 
     bool is_blending = false;
@@ -326,5 +295,51 @@ bool selectbox_draw(const mgc_selectbox_t *selectbox, mgc_framebuffer_t *fb, con
     }
 
     return is_blending;
+}
+
+bool selectbox_draw_cell(
+        const mgc_selectbox_t *selectbox,
+        mgc_pixelbuffer_t *pb,
+        int16_t cell_x,
+        int16_t cell_y,
+        const mgc_point_t *cam_pos,
+        const mgc_draw_options_t *options
+) {
+    if ( ( selectbox == NULL ) ||
+         ( pb == NULL )
+    ) {
+        MGC_WARN("Invalid handler");
+        return false;
+    }
+    if ( selectbox->enabled == false ) {
+        MGC_INFO("Handler is disabled");
+        return false;
+    }
+    if ( selectbox->item_count == 0 ) {
+        MGC_WARN("Empty items");
+        return false;
+    }
+
+    if ( rect_draw_cell(&selectbox->bg_box, pb, cell_x, cell_y, cam_pos, options) == true ) {
+        for ( size_t i = 0; i < selectbox->item_count; i++ ) {
+            label_draw_cell(&selectbox->item[i], pb, cell_x, cell_y, cam_pos, options);
+        }
+        label_draw_cell(&selectbox->cursor, pb, cell_x, cell_y, cam_pos, options);
+        return true;
+    } else {
+        return false;
+    }
+}
+
+// Legacy
+bool selectbox_apply_cell_blending(const mgc_selectbox_t *selectbox, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y) {
+    if ( pixelbuffer == NULL ) {
+        MGC_WARN("Invalid handler");
+        return false;
+    }
+
+    mgc_point_t cam_pos = {pixelbuffer->cell_x_ofs, pixelbuffer->cell_y_ofs};
+
+    return selectbox_draw_cell(selectbox, pixelbuffer, cell_x, cell_y, &cam_pos, NULL);
 }
 

--- a/src/mgc/components/selectbox.c
+++ b/src/mgc/components/selectbox.c
@@ -49,8 +49,8 @@ void selectbox_init(mgc_selectbox_t *selectbox, mgc_id_t id, const mgc_font_t *f
     selectbox->left_margin = 16;
     selectbox->left_cursor_margin = 4;
     selectbox->line_spacing = 4;
-    selectbox->r_cell_x_ofs = 1;
-    selectbox->r_cell_y_ofs = 1;
+    selectbox->parallax_factor_x = 0.0F;
+    selectbox->parallax_factor_y = 0.0F;
 
     rect_init(&selectbox->bg_box, 0);
     rect_set_enabled(&selectbox->bg_box, true);
@@ -85,10 +85,10 @@ void selectbox_append_item(mgc_selectbox_t *selectbox, const char *text) {
     }
     item = &selectbox->item[selectbox->item_count];
     label_set_text(item, text);
-    label_set_r_cell_offset(
+    label_set_parallax_factor(
         item,
-        selectbox->r_cell_x_ofs,
-        selectbox->r_cell_y_ofs
+        selectbox->parallax_factor_x,
+        selectbox->parallax_factor_y
     );
     selectbox->item_count++;
 
@@ -250,17 +250,17 @@ void selectbox_set_fore_color(mgc_selectbox_t *selectbox, mgc_color_t color) {
     }
 }
 
-void selectbox_set_r_cell_offset(mgc_selectbox_t *selectbox, uint8_t r_cell_x_ofs, uint8_t r_cell_y_ofs) {
+void selectbox_set_parallax_factor(mgc_selectbox_t *selectbox, float factor_x, float factor_y) {
     if ( selectbox == NULL ) {
         MGC_WARN("Invalid handler");
         return;
     }
-    selectbox->r_cell_x_ofs = r_cell_x_ofs;
-    selectbox->r_cell_y_ofs = r_cell_y_ofs;
-    rect_set_r_cell_offset(&selectbox->bg_box, r_cell_x_ofs, r_cell_y_ofs);
-    label_set_r_cell_offset(&selectbox->cursor, r_cell_x_ofs, r_cell_y_ofs);
+    selectbox->parallax_factor_x = factor_x;
+    selectbox->parallax_factor_y = factor_y;
+    rect_set_parallax_factor(&selectbox->bg_box, factor_x, factor_y);
+    label_set_parallax_factor(&selectbox->cursor, factor_x, factor_y);
     for ( size_t i = 0; i < selectbox->item_count; i++ ) {
-        label_set_r_cell_offset(&selectbox->item[i], r_cell_x_ofs, r_cell_y_ofs);
+        label_set_parallax_factor(&selectbox->item[i], factor_x, factor_y);
     }
 }
 
@@ -331,7 +331,7 @@ bool selectbox_draw_cell(
     }
 }
 
-// Legacy
+//////////////////////////////// Legacy ////////////////////////////////
 bool selectbox_apply_cell_blending(const mgc_selectbox_t *selectbox, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y) {
     if ( pixelbuffer == NULL ) {
         MGC_WARN("Invalid handler");
@@ -341,5 +341,19 @@ bool selectbox_apply_cell_blending(const mgc_selectbox_t *selectbox, mgc_pixelbu
     mgc_point_t cam_pos = {pixelbuffer->cell_x_ofs, pixelbuffer->cell_y_ofs};
 
     return selectbox_draw_cell(selectbox, pixelbuffer, cell_x, cell_y, &cam_pos, NULL);
+}
+
+void selectbox_set_r_cell_offset(mgc_selectbox_t *selectbox, uint8_t r_cell_x_ofs, uint8_t r_cell_y_ofs) {
+    if ( selectbox == NULL ) {
+        MGC_WARN("Invalid handler");
+        return;
+    }
+    selectbox->parallax_factor_x = (r_cell_x_ofs != 0) ? (1.0F / r_cell_x_ofs) : 0.0F;
+    selectbox->parallax_factor_y = (r_cell_y_ofs != 0) ? (1.0F / r_cell_y_ofs) : 0.0F;
+    rect_set_r_cell_offset(&selectbox->bg_box, r_cell_x_ofs, r_cell_y_ofs);
+    label_set_r_cell_offset(&selectbox->cursor, r_cell_x_ofs, r_cell_y_ofs);
+    for ( size_t i = 0; i < selectbox->item_count; i++ ) {
+        label_set_r_cell_offset(&selectbox->item[i], r_cell_x_ofs, r_cell_y_ofs);
+    }
 }
 

--- a/src/mgc/components/selectbox.h
+++ b/src/mgc/components/selectbox.h
@@ -58,6 +58,7 @@ void selectbox_set_box_border_color(mgc_selectbox_t *selectbox, mgc_color_t colo
 void selectbox_set_fore_color(mgc_selectbox_t *selectbox, mgc_color_t color);
 void selectbox_set_r_cell_offset(mgc_selectbox_t *selectbox, uint8_t r_cell_x_ofs, uint8_t r_cell_y_ofs);
 bool selectbox_apply_cell_blending(const mgc_selectbox_t *selectbox, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y);
+bool selectbox_draw(const mgc_selectbox_t *selectbox, mgc_framebuffer_t *fb, const mgc_point_t *cam_pos, const mgc_draw_options_t *options);
 
 #ifdef __cplusplus
 }/* extern "C" */

--- a/src/mgc/components/selectbox.h
+++ b/src/mgc/components/selectbox.h
@@ -57,8 +57,18 @@ void selectbox_set_box_inner_color(mgc_selectbox_t *selectbox, mgc_color_t color
 void selectbox_set_box_border_color(mgc_selectbox_t *selectbox, mgc_color_t color);
 void selectbox_set_fore_color(mgc_selectbox_t *selectbox, mgc_color_t color);
 void selectbox_set_r_cell_offset(mgc_selectbox_t *selectbox, uint8_t r_cell_x_ofs, uint8_t r_cell_y_ofs);
-bool selectbox_apply_cell_blending(const mgc_selectbox_t *selectbox, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y);
 bool selectbox_draw(const mgc_selectbox_t *selectbox, mgc_framebuffer_t *fb, const mgc_point_t *cam_pos, const mgc_draw_options_t *options);
+bool selectbox_draw_cell(
+        const mgc_selectbox_t *selectbox,
+        mgc_pixelbuffer_t *pb,
+        int16_t cell_x,
+        int16_t cell_y,
+        const mgc_point_t *cam_pos,
+        const mgc_draw_options_t *options
+);
+
+// Legacy
+bool selectbox_apply_cell_blending(const mgc_selectbox_t *selectbox, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y);
 
 #ifdef __cplusplus
 }/* extern "C" */

--- a/src/mgc/components/selectbox.h
+++ b/src/mgc/components/selectbox.h
@@ -36,8 +36,8 @@ typedef struct mgc_selectbox {
     uint8_t left_margin;
     uint8_t left_cursor_margin;
     uint8_t line_spacing;
-    uint8_t r_cell_x_ofs;
-    uint8_t r_cell_y_ofs;
+    float parallax_factor_x;
+    float parallax_factor_y;
 } mgc_selectbox_t;
 
 void selectbox_init(mgc_selectbox_t *selectbox, mgc_id_t id, const mgc_font_t *font, bool fontsize2x);
@@ -56,7 +56,7 @@ void selectbox_change_selected_idx(mgc_selectbox_t *selectbox, bool increment);
 void selectbox_set_box_inner_color(mgc_selectbox_t *selectbox, mgc_color_t color);
 void selectbox_set_box_border_color(mgc_selectbox_t *selectbox, mgc_color_t color);
 void selectbox_set_fore_color(mgc_selectbox_t *selectbox, mgc_color_t color);
-void selectbox_set_r_cell_offset(mgc_selectbox_t *selectbox, uint8_t r_cell_x_ofs, uint8_t r_cell_y_ofs);
+void selectbox_set_parallax_factor(mgc_selectbox_t *selectbox, float factor_x, float factor_y);
 bool selectbox_draw(const mgc_selectbox_t *selectbox, mgc_framebuffer_t *fb, const mgc_point_t *cam_pos, const mgc_draw_options_t *options);
 bool selectbox_draw_cell(
         const mgc_selectbox_t *selectbox,
@@ -67,8 +67,9 @@ bool selectbox_draw_cell(
         const mgc_draw_options_t *options
 );
 
-// Legacy
+//////////////////////////////// Legacy ////////////////////////////////
 bool selectbox_apply_cell_blending(const mgc_selectbox_t *selectbox, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y);
+void selectbox_set_r_cell_offset(mgc_selectbox_t *selectbox, uint8_t r_cell_x_ofs, uint8_t r_cell_y_ofs);
 
 #ifdef __cplusplus
 }/* extern "C" */

--- a/src/mgc/components/sprite.c
+++ b/src/mgc/components/sprite.c
@@ -195,20 +195,6 @@ static inline bool draw_buffer(
     }
 }
 
-
-bool sprite_apply_cell_blending(const mgc_sprite_t *sprite, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y) {
-
-    if ( pixelbuffer == NULL ) {
-        MGC_WARN("Invalid handler");
-        return false;
-    }
-
-    mgc_point_t cam_pos = {pixelbuffer->cell_x_ofs, pixelbuffer->cell_y_ofs};
-    mgc_point_t fov_ofs = {cell_x, cell_y};
-
-    return draw_buffer(sprite, pixelbuffer->pixelbuf, MGC_CELL_LEN, MGC_CELL_LEN, &cam_pos, &fov_ofs, NULL);
-}
-
 bool sprite_draw(const mgc_sprite_t *sprite, mgc_framebuffer_t *fb, const mgc_point_t *cam_pos, const mgc_draw_options_t *options) {
 
     if ( (fb == NULL) || (fb->buffer == NULL) ) {
@@ -219,5 +205,36 @@ bool sprite_draw(const mgc_sprite_t *sprite, mgc_framebuffer_t *fb, const mgc_po
     mgc_point_t fov_ofs = {0, 0};
 
     return draw_buffer(sprite, fb->buffer, fb->width, fb->height, cam_pos, &fov_ofs, options);
+}
+
+bool sprite_draw_cell(
+        const mgc_sprite_t *sprite,
+        mgc_pixelbuffer_t *pb,
+        int16_t cell_x,
+        int16_t cell_y,
+        const mgc_point_t *cam_pos,
+        const mgc_draw_options_t *options
+) {
+    if ( pb == NULL ) {
+        MGC_WARN("Invalid handler");
+        return false;
+    }
+
+    mgc_point_t fov_ofs = {cell_x, cell_y};
+
+    return draw_buffer(sprite, pb->pixelbuf, MGC_CELL_LEN, MGC_CELL_LEN, cam_pos, &fov_ofs, options);
+}
+
+// Legacy
+bool sprite_apply_cell_blending(const mgc_sprite_t *sprite, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y) {
+
+    if ( pixelbuffer == NULL ) {
+        MGC_WARN("Invalid handler");
+        return false;
+    }
+
+    mgc_point_t cam_pos = {pixelbuffer->cell_x_ofs, pixelbuffer->cell_y_ofs};
+
+    return sprite_draw_cell(sprite, pixelbuffer, cell_x, cell_y, &cam_pos, NULL);
 }
 

--- a/src/mgc/components/sprite.c
+++ b/src/mgc/components/sprite.c
@@ -96,7 +96,16 @@ void sprite_set_trim(mgc_sprite_t *sprite, uint16_t left, uint16_t right, uint16
     sprite->trim_bottom = bottom;
 }
 
-bool sprite_apply_cell_blending(const mgc_sprite_t *sprite, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y) {
+static inline bool draw_buffer(
+        const mgc_sprite_t *sprite,
+        mgc_color_t *draw_buf,
+        uint16_t buf_width,
+        uint16_t buf_height,
+        const mgc_point_t *cam_pos,
+        const mgc_point_t *fov_ofs,
+        const mgc_draw_options_t *options
+) {
+    // 0: sprite, 1: camera
     int16_t l0, l1;
     int16_t r0, r1;
     int16_t t0, t1;
@@ -105,7 +114,7 @@ bool sprite_apply_cell_blending(const mgc_sprite_t *sprite, mgc_pixelbuffer_t *p
     if ( ( sprite == NULL ) ||
          ( sprite->tileset == NULL ) ||
          ( sprite->tileset->tile_count == 0 ) ||
-         ( pixelbuffer == NULL )
+         ( draw_buf == NULL )
     ) {
         MGC_WARN("Invalid handler")
         return false;
@@ -114,6 +123,8 @@ bool sprite_apply_cell_blending(const mgc_sprite_t *sprite, mgc_pixelbuffer_t *p
         MGC_INFO("Handler is disabled")
         return false;
     }
+
+    (void)options;
 
     l0 = sprite->x;
     r0 = l0 + sprite->tileset->tile_width - 1;
@@ -128,16 +139,24 @@ bool sprite_apply_cell_blending(const mgc_sprite_t *sprite, mgc_pixelbuffer_t *p
         return false;
     }
 
-    l1 = cell_x;
-    t1 = cell_y;
-    if ( sprite->r_cell_x_ofs != 0 ) {
-        l1 += pixelbuffer->cell_x_ofs / sprite->r_cell_x_ofs;
+    if ( fov_ofs != NULL ) {
+        l1 = fov_ofs->x;
+        t1 = fov_ofs->y;
+    } else {
+        l1 = 0;
+        t1 = 0;
     }
-    if ( sprite->r_cell_y_ofs != 0 ) {
-        t1 += pixelbuffer->cell_y_ofs / sprite->r_cell_y_ofs;
+
+    if ( cam_pos != NULL ) {
+        if ( sprite->r_cell_x_ofs != 0 ) {
+            l1 += cam_pos->x / sprite->r_cell_x_ofs;
+        }
+        if ( sprite->r_cell_y_ofs != 0 ) {
+            t1 += cam_pos->y / sprite->r_cell_y_ofs;
+        }
     }
-    r1 = l1 + MGC_CELL_LEN - 1;
-    b1 = t1 + MGC_CELL_LEN - 1;
+    r1 = l1 + buf_width - 1;
+    b1 = t1 + buf_height - 1;
 
     if ( (l0<=r1) && (l1<=r0) && (t0<=b1) && (t1<=b0) ) {
         int16_t x, y;
@@ -164,10 +183,9 @@ bool sprite_apply_cell_blending(const mgc_sprite_t *sprite, mgc_pixelbuffer_t *p
             for ( y = y_s, wy = y_s*tile_width; y <= y_e; y++, wy+=tile_width ) {
                 color_index = tile[(int32_t)x+wy];
                 if ( color_index != 0 ) {
-                    size_t idx;
+                    size_t idx = MGC_GET_PIXELBUF_INDEX(x+l0-l1, y+t0-t1, buf_width, buf_height);
                     color = palette_array[color_index];
-                    idx = MGC_GET_PIXELBUF_INDEX(x+l0-l1, y+t0-t1);
-                    pixelbuffer->pixelbuf[idx] = MGC_COLOR_SWAP(color);
+                    draw_buf[idx] = MGC_COLOR_SWAP(color);
                 }
             }
         }
@@ -175,5 +193,31 @@ bool sprite_apply_cell_blending(const mgc_sprite_t *sprite, mgc_pixelbuffer_t *p
     } else {
         return false;
     }
+}
+
+
+bool sprite_apply_cell_blending(const mgc_sprite_t *sprite, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y) {
+
+    if ( pixelbuffer == NULL ) {
+        MGC_WARN("Invalid handler");
+        return false;
+    }
+
+    mgc_point_t cam_pos = {pixelbuffer->cell_x_ofs, pixelbuffer->cell_y_ofs};
+    mgc_point_t fov_ofs = {cell_x, cell_y};
+
+    return draw_buffer(sprite, pixelbuffer->pixelbuf, MGC_CELL_LEN, MGC_CELL_LEN, &cam_pos, &fov_ofs, NULL);
+}
+
+bool sprite_draw(const mgc_sprite_t *sprite, mgc_framebuffer_t *fb, const mgc_point_t *cam_pos, const mgc_draw_options_t *options) {
+
+    if ( (fb == NULL) || (fb->buffer == NULL) ) {
+        MGC_WARN("Invalid handler");
+        return false;
+    }
+
+    mgc_point_t fov_ofs = {0, 0};
+
+    return draw_buffer(sprite, fb->buffer, fb->width, fb->height, cam_pos, &fov_ofs, options);
 }
 

--- a/src/mgc/components/sprite.h
+++ b/src/mgc/components/sprite.h
@@ -13,8 +13,9 @@ extern "C" {
 
 #include "mgc/common/common.h"
 #include "mgc/render/pixelbuffer.h"
+#include "mgc/render/framebuffer.h"
 #include "tileset.h"
-#include "tilemap.h"
+//#include "tilemap.h"
 #include "hitbox.h"
 
 typedef struct mgc_sprite {
@@ -43,6 +44,7 @@ void sprite_set_hitbox_array(mgc_sprite_t *sprite, const mgc_hitbox_t *hitbox_ar
 void sprite_set_r_cell_offset(mgc_sprite_t *sprite, uint8_t r_cell_x_ofs, uint8_t r_cell_y_ofs);
 void sprite_set_trim(mgc_sprite_t *sprite, uint16_t left, uint16_t right, uint16_t top, uint16_t bottom);
 bool sprite_apply_cell_blending(const mgc_sprite_t *sprite, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y);
+bool sprite_draw(const mgc_sprite_t *sprite, mgc_framebuffer_t *fb, const mgc_point_t *cam_pos, const mgc_draw_options_t *options);
 
 #ifdef __cplusplus
 }/* extern "C" */

--- a/src/mgc/components/sprite.h
+++ b/src/mgc/components/sprite.h
@@ -43,8 +43,18 @@ void sprite_set_tile_idx(mgc_sprite_t *sprite, size_t tile_idx);
 void sprite_set_hitbox_array(mgc_sprite_t *sprite, const mgc_hitbox_t *hitbox_array, size_t hitbox_count);
 void sprite_set_r_cell_offset(mgc_sprite_t *sprite, uint8_t r_cell_x_ofs, uint8_t r_cell_y_ofs);
 void sprite_set_trim(mgc_sprite_t *sprite, uint16_t left, uint16_t right, uint16_t top, uint16_t bottom);
-bool sprite_apply_cell_blending(const mgc_sprite_t *sprite, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y);
 bool sprite_draw(const mgc_sprite_t *sprite, mgc_framebuffer_t *fb, const mgc_point_t *cam_pos, const mgc_draw_options_t *options);
+bool sprite_draw_cell(
+        const mgc_sprite_t *sprite,
+        mgc_pixelbuffer_t *pb,
+        int16_t cell_x,
+        int16_t cell_y,
+        const mgc_point_t *cam_pos,
+        const mgc_draw_options_t *options
+);
+
+// Legacy
+bool sprite_apply_cell_blending(const mgc_sprite_t *sprite, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y);
 
 #ifdef __cplusplus
 }/* extern "C" */

--- a/src/mgc/components/sprite.h
+++ b/src/mgc/components/sprite.h
@@ -22,8 +22,8 @@ typedef struct mgc_sprite {
     mgc_id_t id;
     int16_t x;
     int16_t y;
-    uint8_t r_cell_x_ofs;
-    uint8_t r_cell_y_ofs;
+    float parallax_factor_x;
+    float parallax_factor_y;
     bool enabled;
     const struct mgc_tileset *tileset;
     size_t tile_idx;
@@ -41,7 +41,7 @@ void sprite_set_position(mgc_sprite_t *sprite, int16_t x, int16_t y);
 void sprite_set_tileset(mgc_sprite_t *sprite, const mgc_tileset_t *tileset);
 void sprite_set_tile_idx(mgc_sprite_t *sprite, size_t tile_idx);
 void sprite_set_hitbox_array(mgc_sprite_t *sprite, const mgc_hitbox_t *hitbox_array, size_t hitbox_count);
-void sprite_set_r_cell_offset(mgc_sprite_t *sprite, uint8_t r_cell_x_ofs, uint8_t r_cell_y_ofs);
+void sprite_set_parallax_factor(mgc_sprite_t *sprite, float factor_x, float factor_y);
 void sprite_set_trim(mgc_sprite_t *sprite, uint16_t left, uint16_t right, uint16_t top, uint16_t bottom);
 bool sprite_draw(const mgc_sprite_t *sprite, mgc_framebuffer_t *fb, const mgc_point_t *cam_pos, const mgc_draw_options_t *options);
 bool sprite_draw_cell(
@@ -53,8 +53,9 @@ bool sprite_draw_cell(
         const mgc_draw_options_t *options
 );
 
-// Legacy
+//////////////////////////////// Legacy ////////////////////////////////
 bool sprite_apply_cell_blending(const mgc_sprite_t *sprite, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y);
+void sprite_set_r_cell_offset(mgc_sprite_t *sprite, uint8_t r_cell_x_ofs, uint8_t r_cell_y_ofs);
 
 #ifdef __cplusplus
 }/* extern "C" */

--- a/src/mgc/components/textblock.c
+++ b/src/mgc/components/textblock.c
@@ -420,19 +420,6 @@ static inline bool draw_buffer(
     return true;
 }
 
-bool textblock_apply_cell_blending(const mgc_textblock_t *textblock, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y) {
-
-    if ( pixelbuffer == NULL ) {
-        MGC_WARN("Invalid handler");
-        return false;
-    }
-
-    mgc_point_t cam_pos = {pixelbuffer->cell_x_ofs, pixelbuffer->cell_y_ofs};
-    mgc_point_t fov_ofs = {cell_x, cell_y};
-
-    return draw_buffer(textblock, pixelbuffer->pixelbuf, MGC_CELL_LEN, MGC_CELL_LEN, &cam_pos, &fov_ofs, NULL);
-}
-
 bool textblock_draw(const mgc_textblock_t *textblock, mgc_framebuffer_t *fb, const mgc_point_t *cam_pos, const mgc_draw_options_t *options) {
 
     if ( (fb == NULL) || (fb->buffer == NULL) ) {
@@ -443,5 +430,36 @@ bool textblock_draw(const mgc_textblock_t *textblock, mgc_framebuffer_t *fb, con
     mgc_point_t fov_ofs = {0, 0};
 
     return draw_buffer(textblock, fb->buffer, fb->width, fb->height, cam_pos, &fov_ofs, options);
+}
+
+bool textblock_draw_cell(
+        const mgc_textblock_t *textblock,
+        mgc_pixelbuffer_t *pb,
+        int16_t cell_x,
+        int16_t cell_y,
+        const mgc_point_t *cam_pos,
+        const mgc_draw_options_t *options
+) {
+    if ( pb == NULL ) {
+        MGC_WARN("Invalid handler");
+        return false;
+    }
+
+    mgc_point_t fov_ofs = {cell_x, cell_y};
+
+    return draw_buffer(textblock, pb->pixelbuf, MGC_CELL_LEN, MGC_CELL_LEN, cam_pos, &fov_ofs, options);
+}
+
+// Legacy
+bool textblock_apply_cell_blending(const mgc_textblock_t *textblock, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y) {
+
+    if ( pixelbuffer == NULL ) {
+        MGC_WARN("Invalid handler");
+        return false;
+    }
+
+    mgc_point_t cam_pos = {pixelbuffer->cell_x_ofs, pixelbuffer->cell_y_ofs};
+
+    return textblock_draw_cell(textblock, pixelbuffer, cell_x, cell_y, &cam_pos, NULL);
 }
 

--- a/src/mgc/components/textblock.h
+++ b/src/mgc/components/textblock.h
@@ -32,8 +32,8 @@ typedef struct mgc_textblock {
     mgc_id_t id;
     int16_t x;
     int16_t y;
-    uint8_t r_cell_x_ofs;
-    uint8_t r_cell_y_ofs;
+    float parallax_factor_x;
+    float parallax_factor_y;
     int16_t width;
     int16_t height;
     const char *text;
@@ -68,7 +68,7 @@ void textblock_set_enable_back_color(mgc_textblock_t *textblock, bool enable);
 void textblock_set_cursor_speed(mgc_textblock_t *textblock, uint8_t cursor_speed);
 void textblock_set_scroll_speed(mgc_textblock_t *textblock, uint8_t scroll_speed);
 void textblock_set_line_spacing(mgc_textblock_t *textblock, uint8_t line_spacing);
-void textblock_set_r_cell_offset(mgc_textblock_t *textblock, uint8_t r_cell_x_ofs, uint8_t r_cell_y_ofs);
+void textblock_set_parallax_factor(mgc_textblock_t *textblock, float factor_x, float factor_y);
 void textblock_set_scroll_line( mgc_textblock_t *textblock, uint8_t scroll_line);
 void textblock_display_update(mgc_textblock_t *textblock);
 void textblock_display_clear(mgc_textblock_t *textblock);
@@ -83,8 +83,9 @@ bool textblock_draw_cell(
         const mgc_draw_options_t *options
 );
 
-// Legacy
+//////////////////////////////// Legacy ////////////////////////////////
 bool textblock_apply_cell_blending(const mgc_textblock_t *textblock, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y);
+void textblock_set_r_cell_offset(mgc_textblock_t *textblock, uint8_t r_cell_x_ofs, uint8_t r_cell_y_ofs);
 
 #ifdef __cplusplus
 }/* extern "C" */

--- a/src/mgc/components/textblock.h
+++ b/src/mgc/components/textblock.h
@@ -73,8 +73,18 @@ void textblock_set_scroll_line( mgc_textblock_t *textblock, uint8_t scroll_line)
 void textblock_display_update(mgc_textblock_t *textblock);
 void textblock_display_clear(mgc_textblock_t *textblock);
 enum mgc_display_text_state textblock_get_display_text_state(const mgc_textblock_t *textblock);
-bool textblock_apply_cell_blending(const mgc_textblock_t *textblock, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y);
 bool textblock_draw(const mgc_textblock_t *textblock, mgc_framebuffer_t *fb, const mgc_point_t *cam_pos, const mgc_draw_options_t *options);
+bool textblock_draw_cell(
+        const mgc_textblock_t *textblock,
+        mgc_pixelbuffer_t *pb,
+        int16_t cell_x,
+        int16_t cell_y,
+        const mgc_point_t *cam_pos,
+        const mgc_draw_options_t *options
+);
+
+// Legacy
+bool textblock_apply_cell_blending(const mgc_textblock_t *textblock, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y);
 
 #ifdef __cplusplus
 }/* extern "C" */

--- a/src/mgc/components/textblock.h
+++ b/src/mgc/components/textblock.h
@@ -15,6 +15,7 @@ extern "C" {
 #include "mgc/font/font.h"
 #include "mgc/font/encoding.h"
 #include "mgc/render/pixelbuffer.h"
+#include "mgc/render/framebuffer.h"
 
 #ifndef MGC_TEXTBLOCK_MAX_LINES
 #define MGC_TEXTBLOCK_MAX_LINES         (16)
@@ -73,6 +74,7 @@ void textblock_display_update(mgc_textblock_t *textblock);
 void textblock_display_clear(mgc_textblock_t *textblock);
 enum mgc_display_text_state textblock_get_display_text_state(const mgc_textblock_t *textblock);
 bool textblock_apply_cell_blending(const mgc_textblock_t *textblock, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y);
+bool textblock_draw(const mgc_textblock_t *textblock, mgc_framebuffer_t *fb, const mgc_point_t *cam_pos, const mgc_draw_options_t *options);
 
 #ifdef __cplusplus
 }/* extern "C" */

--- a/src/mgc/components/tilemap.c
+++ b/src/mgc/components/tilemap.c
@@ -188,7 +188,7 @@ bool tilemap_apply_cell_blending(const mgc_tilemap_t *tilemap, mgc_pixelbuffer_t
                         color_index = tile[x+wy];
                         if ( color_index != 0 ) {
                             size_t idx;
-                            idx = MGC_GET_PIXELBUF_INDEX(x-x_s, y-y_s);
+                            idx = MGC_GET_PIXELBUF_INDEX_OPTIMIZED_16X16(x-x_s, y-y_s);
                             pixelbuf[idx] = MGC_COLOR_SWAP(palette_array[color_index]);
                         }
                     }
@@ -201,7 +201,7 @@ bool tilemap_apply_cell_blending(const mgc_tilemap_t *tilemap, mgc_pixelbuffer_t
                         color_index = tile[x+wy];
                         if ( color_index != 0 ) {
                             size_t idx;
-                            idx = MGC_GET_PIXELBUF_INDEX(x-x_e+MGC_CELL_LEN-1, y-y_s);
+                            idx = MGC_GET_PIXELBUF_INDEX_OPTIMIZED_16X16(x-x_e+MGC_CELL_LEN-1, y-y_s);
                             pixelbuf[idx] = MGC_COLOR_SWAP(palette_array[color_index]);
                         }
                     }
@@ -214,7 +214,7 @@ bool tilemap_apply_cell_blending(const mgc_tilemap_t *tilemap, mgc_pixelbuffer_t
                         color_index = tile[x+wy];
                         if ( color_index != 0 ) {
                             size_t idx;
-                            idx = MGC_GET_PIXELBUF_INDEX(x-x_s, y-y_e+MGC_CELL_LEN-1);
+                            idx = MGC_GET_PIXELBUF_INDEX_OPTIMIZED_16X16(x-x_s, y-y_e+MGC_CELL_LEN-1);
                             pixelbuf[idx] = MGC_COLOR_SWAP(palette_array[color_index]);
                         }
                     }
@@ -227,7 +227,7 @@ bool tilemap_apply_cell_blending(const mgc_tilemap_t *tilemap, mgc_pixelbuffer_t
                         color_index = tile[x+wy];
                         if ( color_index != 0 ) {
                             size_t idx;
-                            idx = MGC_GET_PIXELBUF_INDEX(x-x_e+MGC_CELL_LEN-1, y-y_e+MGC_CELL_LEN-1);
+                            idx = MGC_GET_PIXELBUF_INDEX_OPTIMIZED_16X16(x-x_e+MGC_CELL_LEN-1, y-y_e+MGC_CELL_LEN-1);
                             pixelbuf[idx] = MGC_COLOR_SWAP(palette_array[color_index]);
                         }
                     }
@@ -241,7 +241,7 @@ bool tilemap_apply_cell_blending(const mgc_tilemap_t *tilemap, mgc_pixelbuffer_t
                         color_index = tile[x+wy];
                         if ( color_index != 0 ) {
                             size_t idx;
-                            idx = MGC_GET_PIXELBUF_INDEX(x-x_s, y);
+                            idx = MGC_GET_PIXELBUF_INDEX_OPTIMIZED_16X16(x-x_s, y);
                             pixelbuf[idx] = MGC_COLOR_SWAP(palette_array[color_index]);
                         }
                     }
@@ -254,7 +254,7 @@ bool tilemap_apply_cell_blending(const mgc_tilemap_t *tilemap, mgc_pixelbuffer_t
                         color_index = tile[x+wy];
                         if ( color_index != 0 ) {
                             size_t idx;
-                            idx = MGC_GET_PIXELBUF_INDEX(x-x_e+MGC_CELL_LEN-1, y);
+                            idx = MGC_GET_PIXELBUF_INDEX_OPTIMIZED_16X16(x-x_e+MGC_CELL_LEN-1, y);
                             pixelbuf[idx] = MGC_COLOR_SWAP(palette_array[color_index]);
                         }
                     }
@@ -268,7 +268,7 @@ bool tilemap_apply_cell_blending(const mgc_tilemap_t *tilemap, mgc_pixelbuffer_t
                         color_index = tile[x+wy];
                         if ( color_index != 0 ) {
                             size_t idx;
-                            idx = MGC_GET_PIXELBUF_INDEX(x, y-y_s);
+                            idx = MGC_GET_PIXELBUF_INDEX_OPTIMIZED_16X16(x, y-y_s);
                             pixelbuf[idx] = MGC_COLOR_SWAP(palette_array[color_index]);
                         }
                     }
@@ -281,7 +281,7 @@ bool tilemap_apply_cell_blending(const mgc_tilemap_t *tilemap, mgc_pixelbuffer_t
                         color_index = tile[x+wy];
                         if ( color_index != 0 ) {
                             size_t idx;
-                            idx = MGC_GET_PIXELBUF_INDEX(x, y-y_e+MGC_CELL_LEN-1);
+                            idx = MGC_GET_PIXELBUF_INDEX_OPTIMIZED_16X16(x, y-y_e+MGC_CELL_LEN-1);
                             pixelbuf[idx] = MGC_COLOR_SWAP(palette_array[color_index]);
                         }
                     }
@@ -295,7 +295,7 @@ bool tilemap_apply_cell_blending(const mgc_tilemap_t *tilemap, mgc_pixelbuffer_t
                         color_index = tile[x+wy];
                         if ( color_index != 0 ) {
                             size_t idx;
-                            idx = MGC_GET_PIXELBUF_INDEX(x, y);
+                            idx = MGC_GET_PIXELBUF_INDEX_OPTIMIZED_16X16(x, y);
                             pixelbuf[idx] = MGC_COLOR_SWAP(palette_array[color_index]);
                         }
                     }
@@ -307,3 +307,93 @@ bool tilemap_apply_cell_blending(const mgc_tilemap_t *tilemap, mgc_pixelbuffer_t
         return false;
     }
 }
+
+bool tilemap_draw(const mgc_tilemap_t *tilemap, mgc_framebuffer_t *fb, const mgc_point_t *cam_pos, const mgc_draw_options_t *options) {
+    // 0: tilemap, 1: camera
+    int16_t l0, l1;
+    int16_t r0, r1;
+    int16_t t0, t1;
+    int16_t b0, b1;
+
+    if ( ( tilemap == NULL ) ||
+         ( tilemap->map == NULL ) ||
+         ( tilemap->tileset == NULL ) ||
+         ( tilemap->tileset->tile_width  != MGC_CELL_LEN ) ||
+         ( tilemap->tileset->tile_height != MGC_CELL_LEN ) ||
+         ( fb == NULL ) ||
+         ( fb->buffer == NULL )
+    ) {
+        MGC_WARN("Invalid handler");
+        return false;
+    }
+    if ( tilemap->enabled == false ) {
+        MGC_INFO("Handler is disabled");
+        return false;
+    }
+
+    (void)options;
+
+    l1 = 0;
+    t1 = 0;
+
+    if ( cam_pos != NULL ) {
+        if ( tilemap->r_cell_x_ofs != 0 ) {
+            l1 += cam_pos->x / tilemap->r_cell_x_ofs;
+        }
+        if ( tilemap->r_cell_y_ofs != 0 ) {
+            t1 += cam_pos->y / tilemap->r_cell_y_ofs;
+        }
+    }
+    r1 = l1 + fb->width - 1;
+    b1 = t1 + fb->height - 1;
+
+
+    l0 = tilemap->x;
+    t0 = tilemap->y;
+    r0 = l0 + tilemap->map->map_width * MGC_CELL_LEN - 1;
+    b0 = t0 + tilemap->map->map_height * MGC_CELL_LEN - 1;
+
+    if ( (l0<=r1) && (l1<=r0) && (t0<=b1) && (t1<=b0) ) {
+        const uint8_t tile_count = tilemap->tileset->tile_count;
+        const mgc_color_t *palette_array = tilemap->tileset->palette_array;
+        const uint8_t **tile_array = tilemap->tileset->tile_array;
+        const mgc_map_t *map = tilemap->map;
+        uint16_t i_s, j_s, i_e, j_e;
+        i_s = (l1 <= l0) ? 0 : MGC_DIV_CELL_LEN(l1-l0);
+        j_s = (t1 <= t0) ? 0 : MGC_DIV_CELL_LEN(t1-t0);
+        i_e = (r0 <= r1) ? (map->map_width-1) : MGC_DIV_CELL_LEN(r1-l0);
+        j_e = (b0 <= b1) ? (map->map_height-1) : MGC_DIV_CELL_LEN(b1-t0);
+
+        for ( uint16_t i = i_s; i <= i_e; i++ ) {
+            for ( uint16_t j = j_s; j <= j_e; j++ ) {
+                uint8_t tile_id = map_decompress_and_get_tile_id(map, i, j)&0x7F;
+                if ( (0 < tile_id ) && ( tile_id < tile_count ) ) {
+                    const uint8_t *tile = tile_array[tile_id];
+                    int16_t l2 = l0 + (i * MGC_CELL_LEN);
+                    int16_t r2 = l2 + MGC_CELL_LEN - 1;
+                    int16_t t2 = t0 + (j * MGC_CELL_LEN);
+                    int16_t b2 = t2 + MGC_CELL_LEN - 1;
+                    int16_t x_s = (( l1 < l2 ) ? l2 : l1) - l2;
+                    int16_t x_e = (( r1 < r2 ) ? r1 : r2) - l2;
+                    int16_t y_s = (( t1 < t2 ) ? t2 : t1) - t2;
+                    int16_t y_e = (( b1 < b2 ) ? b1 : b2) - t2;
+                    int16_t x, y;
+                    int32_t wy;
+                    for ( x = x_s; x <= x_e; x++ ) {
+                        for ( y = y_s, wy = y_s*MGC_CELL_LEN; y <= y_e; y++, wy+=MGC_CELL_LEN ) {
+                            int16_t color_index = tile[x + wy];
+                            if ( color_index != 0 ) {
+                                size_t idx = MGC_GET_PIXELBUF_INDEX(x+l2-l1, y+t2-t1, fb->width, fb->height);
+                                fb->buffer[idx] = MGC_COLOR_SWAP(palette_array[color_index]);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return true;
+    } else {
+        return false;
+    }
+}
+

--- a/src/mgc/components/tilemap.c
+++ b/src/mgc/components/tilemap.c
@@ -50,14 +50,110 @@ void tilemap_set_r_cell_offset(mgc_tilemap_t *tilemap, uint8_t r_cell_x_ofs, uin
     tilemap->r_cell_y_ofs = r_cell_y_ofs;
 }
 
-bool tilemap_apply_cell_blending(const mgc_tilemap_t *tilemap, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y) {
+bool tilemap_draw(const mgc_tilemap_t *tilemap, mgc_framebuffer_t *fb, const mgc_point_t *cam_pos, const mgc_draw_options_t *options) {
+    // 0: tilemap, 1: camera
     int16_t l0, l1;
     int16_t r0, r1;
     int16_t t0, t1;
     int16_t b0, b1;
 
     if ( ( tilemap == NULL ) ||
-         ( pixelbuffer == NULL ) ||
+         ( tilemap->map == NULL ) ||
+         ( tilemap->tileset == NULL ) ||
+         ( tilemap->tileset->tile_width  != MGC_CELL_LEN ) ||
+         ( tilemap->tileset->tile_height != MGC_CELL_LEN ) ||
+         ( fb == NULL ) ||
+         ( fb->buffer == NULL )
+    ) {
+        MGC_WARN("Invalid handler");
+        return false;
+    }
+    if ( tilemap->enabled == false ) {
+        MGC_INFO("Handler is disabled");
+        return false;
+    }
+
+    (void)options;
+
+    l1 = 0;
+    t1 = 0;
+
+    if ( cam_pos != NULL ) {
+        if ( tilemap->r_cell_x_ofs != 0 ) {
+            l1 += cam_pos->x / tilemap->r_cell_x_ofs;
+        }
+        if ( tilemap->r_cell_y_ofs != 0 ) {
+            t1 += cam_pos->y / tilemap->r_cell_y_ofs;
+        }
+    }
+    r1 = l1 + fb->width - 1;
+    b1 = t1 + fb->height - 1;
+
+
+    l0 = tilemap->x;
+    t0 = tilemap->y;
+    r0 = l0 + tilemap->map->map_width * MGC_CELL_LEN - 1;
+    b0 = t0 + tilemap->map->map_height * MGC_CELL_LEN - 1;
+
+    if ( (l0<=r1) && (l1<=r0) && (t0<=b1) && (t1<=b0) ) {
+        const uint8_t tile_count = tilemap->tileset->tile_count;
+        const mgc_color_t *palette_array = tilemap->tileset->palette_array;
+        const uint8_t **tile_array = tilemap->tileset->tile_array;
+        const mgc_map_t *map = tilemap->map;
+        uint16_t i_s, j_s, i_e, j_e;
+        i_s = (l1 <= l0) ? 0 : MGC_DIV_CELL_LEN(l1-l0);
+        j_s = (t1 <= t0) ? 0 : MGC_DIV_CELL_LEN(t1-t0);
+        i_e = (r0 <= r1) ? (map->map_width-1) : MGC_DIV_CELL_LEN(r1-l0);
+        j_e = (b0 <= b1) ? (map->map_height-1) : MGC_DIV_CELL_LEN(b1-t0);
+
+        for ( uint16_t i = i_s; i <= i_e; i++ ) {
+            for ( uint16_t j = j_s; j <= j_e; j++ ) {
+                uint8_t tile_id = map_decompress_and_get_tile_id(map, i, j)&0x7F;
+                if ( (0 < tile_id ) && ( tile_id < tile_count ) ) {
+                    const uint8_t *tile = tile_array[tile_id];
+                    int16_t l2 = l0 + (i * MGC_CELL_LEN);
+                    int16_t r2 = l2 + MGC_CELL_LEN - 1;
+                    int16_t t2 = t0 + (j * MGC_CELL_LEN);
+                    int16_t b2 = t2 + MGC_CELL_LEN - 1;
+                    int16_t x_s = (( l1 < l2 ) ? l2 : l1) - l2;
+                    int16_t x_e = (( r1 < r2 ) ? r1 : r2) - l2;
+                    int16_t y_s = (( t1 < t2 ) ? t2 : t1) - t2;
+                    int16_t y_e = (( b1 < b2 ) ? b1 : b2) - t2;
+                    int16_t x, y;
+                    int32_t wy;
+                    for ( x = x_s; x <= x_e; x++ ) {
+                        for ( y = y_s, wy = y_s*MGC_CELL_LEN; y <= y_e; y++, wy+=MGC_CELL_LEN ) {
+                            int16_t color_index = tile[x + wy];
+                            if ( color_index != 0 ) {
+                                size_t idx = MGC_GET_PIXELBUF_INDEX(x+l2-l1, y+t2-t1, fb->width, fb->height);
+                                fb->buffer[idx] = MGC_COLOR_SWAP(palette_array[color_index]);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return true;
+    } else {
+        return false;
+    }
+}
+
+bool tilemap_draw_cell(
+        const mgc_tilemap_t *tilemap,
+        mgc_pixelbuffer_t *pb,
+        int16_t cell_x,
+        int16_t cell_y,
+        const mgc_point_t *cam_pos,
+        const mgc_draw_options_t *options
+) {
+    int16_t l0, l1;
+    int16_t r0, r1;
+    int16_t t0, t1;
+    int16_t b0, b1;
+
+    if ( ( tilemap == NULL ) ||
+         ( pb == NULL ) ||
          ( tilemap->map == NULL ) ||
          ( tilemap->tileset == NULL ) ||
          ( tilemap->tileset->tile_width  != MGC_CELL_LEN ) ||
@@ -77,11 +173,13 @@ bool tilemap_apply_cell_blending(const mgc_tilemap_t *tilemap, mgc_pixelbuffer_t
 
     l1 = cell_x;
     t1 = cell_y;
-    if ( tilemap->r_cell_x_ofs != 0 ) {
-        l1 += pixelbuffer->cell_x_ofs / tilemap->r_cell_x_ofs;
-    }
-    if ( tilemap->r_cell_y_ofs != 0 ) {
-        t1 += pixelbuffer->cell_y_ofs / tilemap->r_cell_y_ofs;
+    if ( cam_pos != NULL ) {
+        if ( tilemap->r_cell_x_ofs != 0 ) {
+            l1 += cam_pos->x / tilemap->r_cell_x_ofs;
+        }
+        if ( tilemap->r_cell_y_ofs != 0 ) {
+            t1 += cam_pos->y / tilemap->r_cell_y_ofs;
+        }
     }
     r1 = l1 + MGC_CELL_LEN - 1;
     b1 = t1 + MGC_CELL_LEN - 1;
@@ -101,7 +199,7 @@ bool tilemap_apply_cell_blending(const mgc_tilemap_t *tilemap, mgc_pixelbuffer_t
         tileset = tilemap->tileset;
         palette_array = tileset->palette_array;
         map = tilemap->map;
-        pixelbuf = pixelbuffer->pixelbuf;
+        pixelbuf = pb->pixelbuf;
 
         /* (left, top) */
         i = l1 - tilemap->x;
@@ -308,92 +406,15 @@ bool tilemap_apply_cell_blending(const mgc_tilemap_t *tilemap, mgc_pixelbuffer_t
     }
 }
 
-bool tilemap_draw(const mgc_tilemap_t *tilemap, mgc_framebuffer_t *fb, const mgc_point_t *cam_pos, const mgc_draw_options_t *options) {
-    // 0: tilemap, 1: camera
-    int16_t l0, l1;
-    int16_t r0, r1;
-    int16_t t0, t1;
-    int16_t b0, b1;
+bool tilemap_apply_cell_blending(const mgc_tilemap_t *tilemap, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y) {
 
-    if ( ( tilemap == NULL ) ||
-         ( tilemap->map == NULL ) ||
-         ( tilemap->tileset == NULL ) ||
-         ( tilemap->tileset->tile_width  != MGC_CELL_LEN ) ||
-         ( tilemap->tileset->tile_height != MGC_CELL_LEN ) ||
-         ( fb == NULL ) ||
-         ( fb->buffer == NULL )
-    ) {
+    if ( pixelbuffer == NULL ) {
         MGC_WARN("Invalid handler");
         return false;
     }
-    if ( tilemap->enabled == false ) {
-        MGC_INFO("Handler is disabled");
-        return false;
-    }
 
-    (void)options;
+    mgc_point_t cam_pos = {pixelbuffer->cell_x_ofs, pixelbuffer->cell_y_ofs};
 
-    l1 = 0;
-    t1 = 0;
-
-    if ( cam_pos != NULL ) {
-        if ( tilemap->r_cell_x_ofs != 0 ) {
-            l1 += cam_pos->x / tilemap->r_cell_x_ofs;
-        }
-        if ( tilemap->r_cell_y_ofs != 0 ) {
-            t1 += cam_pos->y / tilemap->r_cell_y_ofs;
-        }
-    }
-    r1 = l1 + fb->width - 1;
-    b1 = t1 + fb->height - 1;
-
-
-    l0 = tilemap->x;
-    t0 = tilemap->y;
-    r0 = l0 + tilemap->map->map_width * MGC_CELL_LEN - 1;
-    b0 = t0 + tilemap->map->map_height * MGC_CELL_LEN - 1;
-
-    if ( (l0<=r1) && (l1<=r0) && (t0<=b1) && (t1<=b0) ) {
-        const uint8_t tile_count = tilemap->tileset->tile_count;
-        const mgc_color_t *palette_array = tilemap->tileset->palette_array;
-        const uint8_t **tile_array = tilemap->tileset->tile_array;
-        const mgc_map_t *map = tilemap->map;
-        uint16_t i_s, j_s, i_e, j_e;
-        i_s = (l1 <= l0) ? 0 : MGC_DIV_CELL_LEN(l1-l0);
-        j_s = (t1 <= t0) ? 0 : MGC_DIV_CELL_LEN(t1-t0);
-        i_e = (r0 <= r1) ? (map->map_width-1) : MGC_DIV_CELL_LEN(r1-l0);
-        j_e = (b0 <= b1) ? (map->map_height-1) : MGC_DIV_CELL_LEN(b1-t0);
-
-        for ( uint16_t i = i_s; i <= i_e; i++ ) {
-            for ( uint16_t j = j_s; j <= j_e; j++ ) {
-                uint8_t tile_id = map_decompress_and_get_tile_id(map, i, j)&0x7F;
-                if ( (0 < tile_id ) && ( tile_id < tile_count ) ) {
-                    const uint8_t *tile = tile_array[tile_id];
-                    int16_t l2 = l0 + (i * MGC_CELL_LEN);
-                    int16_t r2 = l2 + MGC_CELL_LEN - 1;
-                    int16_t t2 = t0 + (j * MGC_CELL_LEN);
-                    int16_t b2 = t2 + MGC_CELL_LEN - 1;
-                    int16_t x_s = (( l1 < l2 ) ? l2 : l1) - l2;
-                    int16_t x_e = (( r1 < r2 ) ? r1 : r2) - l2;
-                    int16_t y_s = (( t1 < t2 ) ? t2 : t1) - t2;
-                    int16_t y_e = (( b1 < b2 ) ? b1 : b2) - t2;
-                    int16_t x, y;
-                    int32_t wy;
-                    for ( x = x_s; x <= x_e; x++ ) {
-                        for ( y = y_s, wy = y_s*MGC_CELL_LEN; y <= y_e; y++, wy+=MGC_CELL_LEN ) {
-                            int16_t color_index = tile[x + wy];
-                            if ( color_index != 0 ) {
-                                size_t idx = MGC_GET_PIXELBUF_INDEX(x+l2-l1, y+t2-t1, fb->width, fb->height);
-                                fb->buffer[idx] = MGC_COLOR_SWAP(palette_array[color_index]);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        return true;
-    } else {
-        return false;
-    }
+    return tilemap_draw_cell(tilemap, pixelbuffer, cell_x, cell_y, &cam_pos, NULL);
 }
 

--- a/src/mgc/components/tilemap.h
+++ b/src/mgc/components/tilemap.h
@@ -13,6 +13,7 @@ extern "C" {
 
 #include "mgc/common/common.h"
 #include "mgc/render/pixelbuffer.h"
+#include "mgc/render/framebuffer.h"
 #include "map.h"
 #include "tileset.h"
 
@@ -32,6 +33,7 @@ void tilemap_set_enabled(mgc_tilemap_t *tilemap, bool enabled);
 void tilemap_set_position(mgc_tilemap_t *tilemap, int16_t x, int16_t y);
 void tilemap_set_r_cell_offset(mgc_tilemap_t *tilemap, uint8_t r_cell_x_ofs, uint8_t r_cell_y_ofs);
 bool tilemap_apply_cell_blending(const mgc_tilemap_t *tilemap, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y);
+bool tilemap_draw(const mgc_tilemap_t *tilemap, mgc_framebuffer_t *fb, const mgc_point_t *cam_pos, const mgc_draw_options_t *options);
 
 #ifdef __cplusplus
 }/* extern "C" */

--- a/src/mgc/components/tilemap.h
+++ b/src/mgc/components/tilemap.h
@@ -32,8 +32,18 @@ void tilemap_init(mgc_tilemap_t *tilemap, mgc_id_t id, const struct mgc_map *map
 void tilemap_set_enabled(mgc_tilemap_t *tilemap, bool enabled);
 void tilemap_set_position(mgc_tilemap_t *tilemap, int16_t x, int16_t y);
 void tilemap_set_r_cell_offset(mgc_tilemap_t *tilemap, uint8_t r_cell_x_ofs, uint8_t r_cell_y_ofs);
-bool tilemap_apply_cell_blending(const mgc_tilemap_t *tilemap, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y);
 bool tilemap_draw(const mgc_tilemap_t *tilemap, mgc_framebuffer_t *fb, const mgc_point_t *cam_pos, const mgc_draw_options_t *options);
+bool tilemap_draw_cell(
+        const mgc_tilemap_t *tilemap,
+        mgc_pixelbuffer_t *pb,
+        int16_t cell_x,
+        int16_t cell_y,
+        const mgc_point_t *cam_pos,
+        const mgc_draw_options_t *options
+);
+
+// Legacy
+bool tilemap_apply_cell_blending(const mgc_tilemap_t *tilemap, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y);
 
 #ifdef __cplusplus
 }/* extern "C" */

--- a/src/mgc/components/tilemap.h
+++ b/src/mgc/components/tilemap.h
@@ -21,8 +21,8 @@ typedef struct mgc_tilemap {
     mgc_id_t id;
     int16_t x;
     int16_t y;
-    uint8_t r_cell_x_ofs;
-    uint8_t r_cell_y_ofs;
+    float parallax_factor_x;
+    float parallax_factor_y;
     bool enabled;
     const mgc_map_t *map;
     const mgc_tileset_t *tileset;
@@ -31,7 +31,7 @@ typedef struct mgc_tilemap {
 void tilemap_init(mgc_tilemap_t *tilemap, mgc_id_t id, const struct mgc_map *map, const mgc_tileset_t *tileset);
 void tilemap_set_enabled(mgc_tilemap_t *tilemap, bool enabled);
 void tilemap_set_position(mgc_tilemap_t *tilemap, int16_t x, int16_t y);
-void tilemap_set_r_cell_offset(mgc_tilemap_t *tilemap, uint8_t r_cell_x_ofs, uint8_t r_cell_y_ofs);
+void tilemap_set_parallax_factor(mgc_tilemap_t *tilemap, float factor_x, float factor_y);
 bool tilemap_draw(const mgc_tilemap_t *tilemap, mgc_framebuffer_t *fb, const mgc_point_t *cam_pos, const mgc_draw_options_t *options);
 bool tilemap_draw_cell(
         const mgc_tilemap_t *tilemap,
@@ -42,8 +42,9 @@ bool tilemap_draw_cell(
         const mgc_draw_options_t *options
 );
 
-// Legacy
+//////////////////////////////// Legacy ////////////////////////////////
 bool tilemap_apply_cell_blending(const mgc_tilemap_t *tilemap, mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x, int16_t cell_y);
+void tilemap_set_r_cell_offset(mgc_tilemap_t *tilemap, uint8_t r_cell_x_ofs, uint8_t r_cell_y_ofs);
 
 #ifdef __cplusplus
 }/* extern "C" */

--- a/src/mgc/mgc.h
+++ b/src/mgc/mgc.h
@@ -22,6 +22,7 @@ extern "C" {
 #include "components/textblock.h"
 #include "components/tilemap.h"
 #include "render/pixelbuffer.h"
+#include "render/framebuffer.h"
 #include "render/camera.h"
 #include "detector/maphit.h"
 #include "detector/sprhit.h"

--- a/src/mgc/render/camera.c
+++ b/src/mgc/render/camera.c
@@ -17,6 +17,8 @@ void camera_init(mgc_camera_t *camera) {
     camera->y_follow_line = 0;
     camera_set_x_follow_settings(camera, 0, 0, 0);
     camera_set_y_follow_settings(camera, 0, 0, 0);
+    camera->x = 0;
+    camera->y = 0;
 }
 
 void camera_set_x_follow_settings(mgc_camera_t *camera, int16_t start_line, int16_t end_line, uint16_t deadzone) {
@@ -57,12 +59,12 @@ void camera_set_y_follow_enabled(mgc_camera_t *camera, bool enabled) {
     camera->y_enabled = enabled;
 }
 
-void camera_update(mgc_pixelbuffer_t *pixelbuffer, mgc_camera_t *camera, const mgc_sprite_t *target) {
+void camera_follow_target(mgc_camera_t *camera, const mgc_sprite_t *target) {
+
     int16_t dx, dy;
     int16_t next_follow_line;
 
-    if ( ( pixelbuffer == NULL ) ||
-         ( camera == NULL ) ||
+    if ( ( camera == NULL ) ||
          ( target == NULL )
     ) {
         MGC_WARN("Invalid handler");
@@ -110,5 +112,37 @@ void camera_update(mgc_pixelbuffer_t *pixelbuffer, mgc_camera_t *camera, const m
     } else {
         dy = 0;
     }
-    pixelbuffer_add_cell_offset(pixelbuffer, dx, dy);
+
+    camera->x += dx;
+    camera->y += dy;
 }
+
+bool camera_get_position(const mgc_camera_t *camera, mgc_point_t *cam_pos) {
+    if ( ( camera == NULL ) ||
+         ( cam_pos == NULL )
+    ) {
+        MGC_WARN("Invalid handler");
+        return false;
+    }
+
+    cam_pos->x = camera->x;
+    cam_pos->y = camera->y;
+    return true;
+}
+
+// legacy
+void camera_update(mgc_pixelbuffer_t *pixelbuffer, mgc_camera_t *camera, const mgc_sprite_t *target) {
+
+    if ( ( pixelbuffer == NULL ) ||
+         ( camera == NULL ) ||
+         ( target == NULL )
+    ) {
+        MGC_WARN("Invalid handler");
+        return;
+    }
+
+    camera_follow_target(camera, target);
+
+    pixelbuffer_set_cell_offset(pixelbuffer, camera->x, camera->y);
+}
+

--- a/src/mgc/render/camera.c
+++ b/src/mgc/render/camera.c
@@ -130,7 +130,7 @@ bool camera_get_position(const mgc_camera_t *camera, mgc_point_t *cam_pos) {
     return true;
 }
 
-// legacy
+//////////////////////////////// Legacy ////////////////////////////////
 void camera_update(mgc_pixelbuffer_t *pixelbuffer, mgc_camera_t *camera, const mgc_sprite_t *target) {
 
     if ( ( pixelbuffer == NULL ) ||

--- a/src/mgc/render/camera.h
+++ b/src/mgc/render/camera.h
@@ -29,6 +29,8 @@ typedef struct mgc_camera {
     bool y_enabled;
     int16_t x_follow_line;
     int16_t y_follow_line;
+    int16_t x;
+    int16_t y;
 } mgc_camera_t;
 
 void camera_init(mgc_camera_t *camera);
@@ -36,6 +38,10 @@ void camera_set_x_follow_settings(mgc_camera_t *camera, int16_t start_line, int1
 void camera_set_y_follow_settings(mgc_camera_t *camera, int16_t start_line, int16_t end_line, uint16_t deadzone);
 void camera_set_x_follow_enabled(mgc_camera_t *camera, bool enabled);
 void camera_set_y_follow_enabled(mgc_camera_t *camera, bool enabled);
+void camera_follow_target(mgc_camera_t *camera, const mgc_sprite_t *target);
+bool camera_get_position(const mgc_camera_t *camera, mgc_point_t *cam_pos);
+
+// legacy
 void camera_update(mgc_pixelbuffer_t *pixelbuffer, mgc_camera_t *camera, const mgc_sprite_t *target);
 
 #ifdef __cplusplus

--- a/src/mgc/render/camera.h
+++ b/src/mgc/render/camera.h
@@ -41,7 +41,7 @@ void camera_set_y_follow_enabled(mgc_camera_t *camera, bool enabled);
 void camera_follow_target(mgc_camera_t *camera, const mgc_sprite_t *target);
 bool camera_get_position(const mgc_camera_t *camera, mgc_point_t *cam_pos);
 
-// legacy
+//////////////////////////////// Legacy ////////////////////////////////
 void camera_update(mgc_pixelbuffer_t *pixelbuffer, mgc_camera_t *camera, const mgc_sprite_t *target);
 
 #ifdef __cplusplus

--- a/src/mgc/render/framebuffer.c
+++ b/src/mgc/render/framebuffer.c
@@ -1,0 +1,49 @@
+/*
+ * MIT License
+ * (https://opensource.org/license/mit/)
+ *
+ * Copyright (c) 2025 nyannkov
+ */
+#include <string.h>
+#include "framebuffer.h"
+
+
+void framebuffer_init(mgc_framebuffer_t *fb, mgc_color_t *buffer, uint16_t width, uint16_t height) {
+    if ( ( fb == NULL ) ||
+         ( buffer == NULL ) ||
+         ( width == 0 ) ||
+         ( height == 0 )
+    ) {
+        MGC_WARN("Invalid handler");
+        return;
+    }
+
+    fb->buffer = buffer;
+    fb->width = width;
+    fb->height = height;
+}
+
+void framebuffer_clear(mgc_framebuffer_t *fb, mgc_color_t color) {
+    mgc_color_t *dest;
+    size_t len;
+
+    if ( ( fb == NULL ) ||
+         ( fb->buffer == NULL ) ||
+         ( fb->width <= 0 ) ||
+         ( fb->height <= 0 )
+    ) {
+        MGC_WARN("Invalid handler");
+        return;
+    }
+
+    dest = fb->buffer;
+    len = (size_t)(fb->width) * (size_t)(fb->height);
+
+    while ( len > 0 ) {
+        *dest = MGC_COLOR_SWAP(color);
+        dest++;
+        len--;
+    }
+}
+
+

--- a/src/mgc/render/framebuffer.c
+++ b/src/mgc/render/framebuffer.c
@@ -4,7 +4,6 @@
  *
  * Copyright (c) 2025 nyannkov
  */
-#include <string.h>
 #include "framebuffer.h"
 
 

--- a/src/mgc/render/framebuffer.h
+++ b/src/mgc/render/framebuffer.h
@@ -1,0 +1,29 @@
+/*
+ * MIT License
+ * (https://opensource.org/license/mit/)
+ *
+ * Copyright (c) 2025 nyannkov
+ */
+#ifndef MGC_FRAMEBUFFER_H
+#define MGC_FRAMEBUFFER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "mgc/common/common.h"
+
+typedef struct mgc_framebuffer {
+    mgc_color_t *buffer;
+    uint16_t width;
+    uint16_t height;
+} mgc_framebuffer_t;
+
+void framebuffer_init(mgc_framebuffer_t *fb, mgc_color_t *buffer, uint16_t width, uint16_t height);
+void framebuffer_clear(mgc_framebuffer_t *fb, mgc_color_t color);
+
+#ifdef __cplusplus
+}/* extern "C" */
+#endif
+
+#endif/*MGC_FRAMEBUFFER_H*/

--- a/src/mgc/render/pixelbuffer.c
+++ b/src/mgc/render/pixelbuffer.c
@@ -90,6 +90,7 @@ void pixelbuffer_set_refresh_mode(mgc_pixelbuffer_t *pixelbuffer, bool refresh_m
     pixelbuffer->refresh_mode = refresh_mode;
 }
 
+//////////////////////////////// Legacy ////////////////////////////////
 void pixelbuffer_set_cell_offset(mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x_ofs, int16_t cell_y_ofs) {
     if ( pixelbuffer == NULL ) {
         MGC_WARN("Invalid handler");

--- a/src/mgc/render/pixelbuffer.h
+++ b/src/mgc/render/pixelbuffer.h
@@ -20,8 +20,8 @@ typedef struct mgc_pixelbuffer {
     mgc_color_t pixelbuf[PIXELBUF_LEN];
     mgc_color_t back_color;
     bool refresh_mode;
-    int16_t cell_x_ofs;
-    int16_t cell_y_ofs;
+    int16_t cell_x_ofs; // Legacy
+    int16_t cell_y_ofs; // Legacy
 } mgc_pixelbuffer_t;
 
 void pixelbuffer_init(mgc_pixelbuffer_t *pixelbuffer);
@@ -30,6 +30,8 @@ void pixelbuffer_fill_with_color(mgc_pixelbuffer_t *pixelbuffer, mgc_color_t col
 void pixelbuffer_fill_partial_with_color(mgc_pixelbuffer_t *pixelbuffer, mgc_color_t color, int16_t fill_dx, int16_t fill_dy);
 void pixelbuffer_set_refresh_mode(mgc_pixelbuffer_t *pixelbuffer, bool refresh_mode);
 void pixelbuffer_set_back_color(mgc_pixelbuffer_t *pixelbuffer, mgc_color_t back_color);
+
+//////////////////////////////// Legacy ////////////////////////////////
 void pixelbuffer_set_cell_offset(mgc_pixelbuffer_t *pixelbuffer, int16_t cell_x_ofs, int16_t cell_y_ofs);
 void pixelbuffer_add_cell_offset(mgc_pixelbuffer_t *pixelbuffer, int16_t dx, int16_t dy);
 void pixelbuffer_draw_cell(mgc_pixelbuffer_t *pixelbuffer, const mgc_display_if_t *driver, int16_t cell_x, int16_t cell_y);


### PR DESCRIPTION
# Description

This pull request introduces a new framebuffer abstraction `mgc_framebuffer_t` and refactors related parts of the codebase to adopt it. The aim is to clarify the separation of responsibilities between framebuffer and pixelbuffer, enhance code maintainability, and allow more flexible rendering strategies.

# Changes

- Added `mgc_framebuffer_t` structure
- Updated drawing functions to accept framebuffer where applicable
- Refactored camera scroll behavior to receive camera position via arguments
- Retained legacy APIs for backward compatibility