### PR TITLE
Fix boxmap collision pushback calculation

### DIFF
--- a/src/mgc/detector/collision_boxbox.c
+++ b/src/mgc/detector/collision_boxbox.c
@@ -18,45 +18,6 @@ static inline void accumulate_pushback_neg(mgc_world_t* dst, mgc_world_t v) {
     }
 }
 
-static mgc_contact_t calc_contact_flags_box_box(
-    const mgc_aabb_t *aa,
-    const mgc_aabb_t *bb
-) {
-    mgc_contact_t flags = 0;
-    
-    if ( collision_point_in_box(aa->l, aa->t, bb->l, bb->r, bb->t, bb->b) ) {
-        flags |= (MGC_CONTACT_LT|MGC_CONTACT_L|MGC_CONTACT_T);
-    }
-    if ( collision_point_in_box(aa->r, aa->t, bb->l, bb->r, bb->t, bb->b) ) {
-        flags |= (MGC_CONTACT_RT|MGC_CONTACT_R|MGC_CONTACT_T);
-    }
-    if ( collision_point_in_box(aa->l, aa->b, bb->l, bb->r, bb->t, bb->b) ) {
-        flags |= (MGC_CONTACT_LB|MGC_CONTACT_L|MGC_CONTACT_B);
-    }
-    if ( collision_point_in_box(aa->r, aa->b, bb->l, bb->r, bb->t, bb->b) ) {
-        flags |= (MGC_CONTACT_RB|MGC_CONTACT_R|MGC_CONTACT_B);
-    }
-
-    if ( (aa->t < bb->t) && (bb->b < aa->b) ) {
-        if ( (bb->l <= aa->l) && (aa->l <= bb->r) ) {
-            flags |= MGC_CONTACT_L;
-        }
-        if ( (bb->l <= aa->r) && (aa->r <= bb->r) ) {
-            flags |= MGC_CONTACT_R;
-        }
-    }
-    if ( (aa->l < bb->l) && (bb->r < aa->r) ) {
-        if ( (bb->t <= aa->t) && (aa->t <= bb->b) ) {
-            flags |= MGC_CONTACT_T;
-        }
-        if ( (bb->t <= aa->b) && (aa->b <= bb->b) ) {
-            flags |= MGC_CONTACT_B;
-        }
-    }
-
-    return flags;
-}
-
 void collision_boxbox_init(
     mgc_collision_boxbox_t* boxbox,
     const mgc_hitbox_t *hitbox,
@@ -117,7 +78,7 @@ bool collision_boxbox_test_hit(
 
     bool r = collision_test_hit(&boxbox->aa, &bb);
     if ( r ) {
-        boxbox->flags |= calc_contact_flags_box_box(&boxbox->aa, &bb);
+        boxbox->flags |= collision_calc_contact_flags(&boxbox->aa, &bb);
     }
 
     return r;

--- a/src/mgc/detector/collision_boxmap.c
+++ b/src/mgc/detector/collision_boxmap.c
@@ -124,30 +124,24 @@ bool collision_boxmap_test_hit_cell(
         *hit_map_cell_value = map_cell_value;
     }
 
-    if ( col == map_range->col_min ) {
-        if ( row == map_range->row_min ) {
-            boxmap->flags |= MGC_CONTACT_LT;
-        } else if ( row == map_range->row_max ) {
-            boxmap->flags |= MGC_CONTACT_LB;
-        } else {
-            boxmap->flags |= MGC_CONTACT_L;
-        }
-    } else if ( col == map_range->col_max ) {
-        if ( row == map_range->row_min ) {
-            boxmap->flags |= MGC_CONTACT_RT;
-        } else if ( row == map_range->row_max ) {
-            boxmap->flags |= MGC_CONTACT_RB;
-        } else {
-            boxmap->flags |= MGC_CONTACT_R;
-        }
-    } else {
-        if ( row == map_range->row_min ) {
-            boxmap->flags |= MGC_CONTACT_T;
-        } else if ( row == map_range->row_max ) {
-            boxmap->flags |= MGC_CONTACT_B;
-        } else {
-        }
-    }
+    mgc_aabb_t target, cell;
+
+    collision_calc_aabb_from_hitbox(
+        boxmap->box_x,
+        boxmap->box_y,
+        boxmap->box,
+        &target
+    );
+
+    collision_calc_aabb_from_cell(
+        boxmap->map_x,
+        boxmap->map_y,
+        row,
+        col,
+        &cell
+    );
+
+    boxmap->flags |= collision_calc_contact_flags(&target, &cell);
 
     return true;
 }
@@ -165,7 +159,7 @@ bool collision_boxmap_test_hit(
     for ( uint16_t row = map_range->row_min;; ++row ) {
         for ( uint16_t col = map_range->col_min;; ++col ) {
 
-            r |= collision_boxmap_test_hit_cell(boxmap, row, col, map_range, NULL);
+            r = collision_boxmap_test_hit_cell(boxmap, row, col, map_range, NULL) || r;
             if ( col == map_range->col_max ) break;
         }
         if ( row == map_range->row_max ) break;

--- a/src/mgc/detector/collision_common.c
+++ b/src/mgc/detector/collision_common.c
@@ -32,6 +32,21 @@ void collision_calc_aabb_from_hitbox(
     out->b = out->t + hitbox->height - 1;
 }
 
+void collision_calc_aabb_from_cell(
+    mgc_world_t map_x,
+    mgc_world_t map_y,
+    uint16_t row,
+    uint16_t col,
+    mgc_aabb_t *out
+) {
+    MGC_ASSERT(out != NULL, "`out` must not be NULL");
+
+    out->l = map_x + col * MGC_CELL_LEN;
+    out->r = out->l + MGC_CELL_LEN - 1;
+    out->t = map_y + row * MGC_CELL_LEN;
+    out->b = out->t + MGC_CELL_LEN - 1;
+}
+
 void collision_expand_aabb_margin(
     const mgc_aabb_t* src,
     const mgc_aabb_margin_t* m,
@@ -107,5 +122,44 @@ bool collision_calc_signed_overlap(
     }
 
     return true;
+}
+
+mgc_contact_t collision_calc_contact_flags(
+    const mgc_aabb_t *aa,
+    const mgc_aabb_t *bb
+) {
+    mgc_contact_t flags = 0;
+    
+    if ( collision_point_in_box(aa->l, aa->t, bb->l, bb->r, bb->t, bb->b) ) {
+        flags |= (MGC_CONTACT_LT|MGC_CONTACT_L|MGC_CONTACT_T);
+    }
+    if ( collision_point_in_box(aa->r, aa->t, bb->l, bb->r, bb->t, bb->b) ) {
+        flags |= (MGC_CONTACT_RT|MGC_CONTACT_R|MGC_CONTACT_T);
+    }
+    if ( collision_point_in_box(aa->l, aa->b, bb->l, bb->r, bb->t, bb->b) ) {
+        flags |= (MGC_CONTACT_LB|MGC_CONTACT_L|MGC_CONTACT_B);
+    }
+    if ( collision_point_in_box(aa->r, aa->b, bb->l, bb->r, bb->t, bb->b) ) {
+        flags |= (MGC_CONTACT_RB|MGC_CONTACT_R|MGC_CONTACT_B);
+    }
+
+    if ( (aa->t < bb->t) && (bb->b < aa->b) ) {
+        if ( (bb->l <= aa->l) && (aa->l <= bb->r) ) {
+            flags |= MGC_CONTACT_L;
+        }
+        if ( (bb->l <= aa->r) && (aa->r <= bb->r) ) {
+            flags |= MGC_CONTACT_R;
+        }
+    }
+    if ( (aa->l < bb->l) && (bb->r < aa->r) ) {
+        if ( (bb->t <= aa->t) && (aa->t <= bb->b) ) {
+            flags |= MGC_CONTACT_T;
+        }
+        if ( (bb->t <= aa->b) && (aa->b <= bb->b) ) {
+            flags |= MGC_CONTACT_B;
+        }
+    }
+
+    return flags;
 }
 

--- a/src/mgc/detector/collision_common.h
+++ b/src/mgc/detector/collision_common.h
@@ -79,6 +79,14 @@ void collision_calc_aabb_from_hitbox(
     mgc_aabb_t *out
 );
 
+void collision_calc_aabb_from_cell(
+    mgc_world_t map_x,
+    mgc_world_t map_y,
+    uint16_t row,
+    uint16_t col,
+    mgc_aabb_t *out
+);
+
 void collision_expand_aabb_margin(
     const mgc_aabb_t* src,
     const mgc_aabb_margin_t* m,
@@ -97,6 +105,10 @@ bool collision_calc_signed_overlap(
     mgc_world_t *out_y
 );
 
+mgc_contact_t collision_calc_contact_flags(
+    const mgc_aabb_t *aa,
+    const mgc_aabb_t *bb
+);
 
 #ifdef __cplusplus
 }/* extern "C" */


### PR DESCRIPTION
Before: Pushback was calculated correctly only when the hitbox was fully inside the map.
After: Now it calculates correctly even when the hitbox goes outside the map boundaries.